### PR TITLE
srvgrp-device-power: Add request field for get fast channel service id

### DIFF
--- a/src/srvgrp-performance.adoc
+++ b/src/srvgrp-performance.adoc
@@ -420,6 +420,7 @@ This service allows clients to query attributes of the fast channel for the spec
 |===
 | Word	| Name 		| Type		| Description
 | 0	| DOMAIN_ID	| uint32	| Performance domain ID
+| 1	| SERVICE_ID	| uint32	| Performance service ID, see service ID in <<table_perf_services>>
 |===
 
 [#table_perf_getfastchanaddr_response_data]


### PR DESCRIPTION
The request of 'GET_PERF_DOMAIN_FAST_CHANNEL_ADDR' requires additional field to differentiate the
fast channel address of level/limit get/set.