### PR TITLE
srvgrp: Add prefix to all services

### DIFF
--- a/src/srvgrp-base.adoc
+++ b/src/srvgrp-base.adoc
@@ -50,15 +50,15 @@ Below table lists the services in this group:
 .Base Services
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
-| Service ID	| Service Name 			| Request Type
-| 0x01		| ENABLE_NOTIFICATION		| NORMAL_REQUEST
-| 0x02		| GET_IMPLEMENTATION_VERSION	| NORMAL_REQUEST
-| 0x03		| GET_IMPLEMENTATION_ID		| NORMAL_REQUEST
-| 0x04		| GET_SPEC_VERSION		| NORMAL_REQUEST
-| 0x05		| GET_HW_INFO			| NORMAL_REQUEST
-| 0x06		| PROBE_SERVICE_GROUP		| NORMAL_REQUEST
-| 0x07		| GET_BASE_ATTRIBUTES		| NORMAL_REQUEST
-| 0x08		| SET_MSI			| NORMAL_REQUEST
+| Service ID	| Service Name 				| Request Type
+| 0x01		| BASE_ENABLE_NOTIFICATION		| NORMAL_REQUEST
+| 0x02		| BASE_GET_IMPLEMENTATION_VERSION	| NORMAL_REQUEST
+| 0x03		| BASE_GET_IMPLEMENTATION_ID		| NORMAL_REQUEST
+| 0x04		| BASE_GET_SPEC_VERSION			| NORMAL_REQUEST
+| 0x05		| BASE_GET_HW_INFO			| NORMAL_REQUEST
+| 0x06		| BASE_PROBE_SERVICE_GROUP		| NORMAL_REQUEST
+| 0x07		| BASE_GET_BASE_ATTRIBUTES		| NORMAL_REQUEST
+| 0x08		| BASE_SET_MSI				| NORMAL_REQUEST
 |===
 
 ==== Base Notifications
@@ -77,7 +77,7 @@ this event may send the list of messages which the Platform Microcontroller was 
 notification
 |===
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *BASE_ENABLE_NOTIFICATION*
 This service allows AP to subscribe to Base service group notifications. +
 Platform can optionally support notifications of errors which might occur in the platform. PuC can send these notification messages to AP if they are implemented
 and AP has subscribed to these. Events supported are described above in Base Notifications. 
@@ -106,7 +106,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_IMPLEMENTATION_VERSION*
+==== Service: *BASE_GET_IMPLEMENTATION_VERSION*
 Get the implementation version of the message framework from Platform Microcontroller. Versioning is also done for the spec but it's possible that for a single version of spec there may be multiple implementation versions and based on that any lowest supported implementation version can be mandated to ensure the stability and support. Version returned using this service is a 32 bits composite number which contains both Major and Minor numbers.
 
 [#table_base_getimplversion_request_data]
@@ -134,7 +134,7 @@ Get the implementation version of the message framework from Platform Microcontr
 !===
 |===
 
-==== Service: *GET_IMPLEMENTATION_ID*
+==== Service: *BASE_GET_IMPLEMENTATION_ID*
 Get the RPMI Implementation ID assigned to the Operating system or Firmware or any other software host which implements the RPMI specification.
 [#table_base_getimplid_request_data]
 .Request Data
@@ -155,7 +155,7 @@ Get the RPMI Implementation ID assigned to the Operating system or Firmware or a
 | 1	| IMPL_ID	| uint32	| Implementation ID
 |===
 
-==== Service: *GET_SPEC_VERSION*
+==== Service: *BASE_GET_SPEC_VERSION*
 Get version of the implemented RPMI specification
 [#table_base_getspecversion_request_data]
 .Request Data
@@ -182,7 +182,7 @@ Get version of the implemented RPMI specification
 !===
 |===
 
-==== Service: *GET_HW_INFO*
+==== Service: *BASE_GET_HW_INFO*
 This service is used to retrieve the Vendor ID and Name of the Vendor having an
 RPMI implementation on PuC. Each vendor will be assigned a unique Vendor ID.
 [#table_base_gethwinfo_request_data]
@@ -223,7 +223,7 @@ RPMI implementation on PuC. Each vendor will be assigned a unique Vendor ID.
 			hardware.
 |===
 
-==== Service: *PROBE_SERVICE_GROUP*
+==== Service: *BASE_PROBE_SERVICE_GROUP*
 Probe the implementation of any service group by its service group id. Except 
 BASE, rest of the service groups are optional but if a service group is 
 implemented then it has to be implemented completely with all services in that group. The notifications in that service group are still optional which will be implemented by the PuC.
@@ -258,7 +258,7 @@ implemented then it has to be implemented completely with all services in that g
 	1: Service group implemented by platform.
 |===
 
-==== Service: *GET_BASE_ATTRIBUTES*
+==== Service: *BASE_GET_BASE_ATTRIBUTES*
 This service is used to discover additional features supported by the base service group.
 [#table_base_getbaseattrs_request_data]
 .Request Data
@@ -296,7 +296,7 @@ This service is used to discover additional features supported by the base servi
 | 4 	| FLAGS3	| uint32	| _Reserved, initialized to_ `0`
 |===
 
-==== Service: *SET_MSI*
+==== Service: *BASE_SET_MSI*
 Configure the MSI address and data which the Platform Microcontroller can use as a doorbell to AP.
 
 The PuC to AP MSI can be used for both sending MSI or injecting wired interrupts. If the MSI target address is IMSIC then AP will take MSI whereas if the MSI target address is "setipnum" of APLIC then AP will take wired interrupt.

--- a/src/srvgrp-clock.adoc
+++ b/src/srvgrp-clock.adoc
@@ -26,21 +26,21 @@ Below table lists the services in this group:
 .Clock Services
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
-| Service ID	| Service Name 		| Request Type
-| 0x01		| ENABLE_NOTIFICATION	| NORMAL_REQUEST
-| 0x02		| GET_NUM_CLOCKS	| NORMAL_REQUEST
-| 0x03		| GET_ATTRIBUTES	| NORMAL_REQUEST
-| 0x04		| GET_SUPPORTED_RATES	| NORMAL_REQUEST
-| 0x05		| SET_CONFIG		| NORMAL_REQUEST
-| 0x06		| GET_CONFIG		| NORMAL_REQUEST
-| 0x07		| SET_RATE		| NORMAL_REQUEST
-| 0x08		| GET_RATE		| NORMAL_REQUEST
+| Service ID	| Service Name 			| Request Type
+| 0x01		| CLK_ENABLE_NOTIFICATION	| NORMAL_REQUEST
+| 0x02		| CLK_GET_NUM_CLOCKS		| NORMAL_REQUEST
+| 0x03		| CLK_GET_ATTRIBUTES		| NORMAL_REQUEST
+| 0x04		| CLK_GET_SUPPORTED_RATES	| NORMAL_REQUEST
+| 0x05		| CLK_SET_CONFIG		| NORMAL_REQUEST
+| 0x06		| CLK_GET_CONFIG		| NORMAL_REQUEST
+| 0x07		| CLK_SET_RATE			| NORMAL_REQUEST
+| 0x08		| CLK_GET_RATE			| NORMAL_REQUEST
 |===
 
 ==== Clock Notifications
 This service group does not support any event for notification
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *CLK_ENABLE_NOTIFICATION*
 This service allows the AP to subscribe to clock service group notifications.
 The platform can optionally support notifications of events which might occur in
 the platform. The PuC can send these notification messages to AP if they are
@@ -72,7 +72,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_NUM_CLOCKS*
+==== Service: *CLK_GET_NUM_CLOCKS*
 This service is used to query the number of clocks available in the system.
 All supported clocks in the system are designated by an integer identifier
 called CLOCK_ID. CLOCK_ID are sequential starting from `0`.
@@ -96,7 +96,7 @@ called CLOCK_ID. CLOCK_ID are sequential starting from `0`.
 | 1	|	NUM_CLOCKS	| uint32 	| Number of Clocks
 |===
 
-==== Service: *GET_ATTRIBUTES*
+==== Service: *CLK_GET_ATTRIBUTES*
 This service provides detailed attributes of a clock, including its name,
 represented as a 16-byte array of ASCII strings. It also specifies the
 transition latency, which denotes the maximum time for the clock to stabilize
@@ -152,7 +152,7 @@ the future, as needed.
 | 4:7	| CLOCK_NAME		| uint8[16]	| Clock name
 |===
 
-==== Service: *GET_SUPPORTED_RATES*
+==== Service: *CLK_GET_SUPPORTED_RATES*
 Each domain may support multiple clock rate values which are allowed by the 
 domain to operate. Message can also pass the `CLOCK_RATE_INDEX` which is the index
 to the first rate value to be described in the return rate array. If all 
@@ -204,7 +204,7 @@ In case the CLOCK_FORMAT is a linear range the RETURNED field will be set to `3`
 | ...	| CLOCK_RATE[N-1] | (uint32, uint32) | Clock rate value.
 |===
 
-==== Service: *SET_CONFIG*
+==== Service: *CLK_SET_CONFIG*
 Set clock config, enable or disable the clock.
 
 [#table_clock_setconfig_request_data]
@@ -243,7 +243,7 @@ Set clock config, enable or disable the clock.
 |===
 
 
-==== Service: *GET_CONFIG*
+==== Service: *CLK_GET_CONFIG*
 Get the current status of a clock, if it's enabled or disabled.
 
 [#table_clock_getconfig_request_data]
@@ -276,7 +276,7 @@ Get the current status of a clock, if it's enabled or disabled.
 !===
 |===
 
-==== Service: *SET_RATE*
+==== Service: *CLK_SET_RATE*
 Set clock rate.
 
 [#table_clock_setrate_request_data]
@@ -320,7 +320,7 @@ Set clock rate.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_RATE*
+==== Service: *CLK_GET_RATE*
 Get the current clock rate value.
 
 [#table_clock_getrate_request_data]

--- a/src/srvgrp-cppc.adoc
+++ b/src/srvgrp-cppc.adoc
@@ -16,11 +16,11 @@ CPPC Fast-channel REQ-ACK Memory Entry per Hart:
 .CPPC Fast-Channel Memory Entry
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
-| Word	| Description 			| Entity which writes the word
+| Word	| Description 				| Entity which writes the word
 | 0	| Request Sequence Number Register	| AP
-| 1	| Request Register		| AP
-| 2	| Acknowledgement Register	| PuC
-| 3	| Reserved			| None
+| 1	| Request Register			| AP
+| 2	| Acknowledgement Register		| PuC
+| 3	| Reserved				| None
 |===
 
 Below table lists the services in this group:
@@ -28,14 +28,14 @@ Below table lists the services in this group:
 .CPPC Services
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
-| Service ID	| Service Name 			| Request Type
-| 0x01		| ENABLE_NOTIFICATION		| NORMAL_REQUEST
-| 0x02		| PROBE_REG			| NORMAL_REQUEST
-| 0x03		| READ_REG			| NORMAL_REQUEST
-| 0x04		| WRITE_REG			| NORMAL_REQUEST
-| 0x05		| GET_FAST_CHANNEL_ATTRIBUTES	| NORMAL_REQUEST
-| 0x06		| POKE_FAST_CHANNEL		| NORMAL_REQUEST
-| 0x07		| GET_HART_LIST			| NORMAL_REQUEST
+| Service ID	| Service Name 				| Request Type
+| 0x01		| CPPC_ENABLE_NOTIFICATION		| NORMAL_REQUEST
+| 0x02		| CPPC_PROBE_REG			| NORMAL_REQUEST
+| 0x03		| CPPC_READ_REG				| NORMAL_REQUEST
+| 0x04		| CPPC_WRITE_REG			| NORMAL_REQUEST
+| 0x05		| CPPC_GET_FAST_CHANNEL_ATTRIBUTES	| NORMAL_REQUEST
+| 0x06		| CPPC_POKE_FAST_CHANNEL		| NORMAL_REQUEST
+| 0x07		| CPPC_GET_HART_LIST			| NORMAL_REQUEST
 |===
 
 ==== CPPC Notifications
@@ -43,7 +43,7 @@ This service group does not support any event for notification.
 
 
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *CPPC_ENABLE_NOTIFICATION*
 This service allows AP to subscribe to CPPC service group notifications.
 Platform can optionally support notifications of events which might occur in the platform. PuC can send these notification messages to AP if they are implemented
 and AP has subscribed to these. Events supported are described above in CPPC Notifications. 
@@ -75,7 +75,7 @@ notification.
 
 
 
-==== Service: *PROBE_REG*
+==== Service: *CPPC_PROBE_REG*
 Probe for CPPC register and get its length in bytes. If the register is not 
 implemented, REG_LENGTH returned will be zero.
 
@@ -107,7 +107,7 @@ https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/src/ext-cppc.adoc[SBI
 
 
 
-==== Service: *READ_REG*
+==== Service: *CPPC_READ_REG*
 Read CPPC register value
 
 [#table_cppc_readreg_request_data]
@@ -141,7 +141,7 @@ probe the REG_ID before reading.
 
 
 
-==== Service: *WRITE_REG*
+==== Service: *CPPC_WRITE_REG*
 Write a CPPC register
 
 [#table_cppc_writereg_request_data]
@@ -175,7 +175,7 @@ probe the REG_ID before reading.
 
 
 
-==== Service: *GET_FAST_CHANNEL_ATTRIBUTES*
+==== Service: *CPPC_GET_FAST_CHANNEL_ATTRIBUTES*
 This request retrieves attributes of the Fast-channel for a specified hart ID.
 The physical address from this request shall be used to write the value of the https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/08_Processor_Configuration_and_Control/declaring-processors.html?highlight=desired-performance-register#desired-performance-register[CPPC Desired 
 Performance Register].
@@ -228,7 +228,7 @@ Performance Register].
 
 
 
-==== Service: *POKE_FAST_CHANNEL*
+==== Service: *CPPC_POKE_FAST_CHANNEL*
 Debug request message to poke the PuC FW to process the pending CPPC messages if
 any.
 
@@ -253,7 +253,7 @@ any.
 
 
 
-==== Service: *GET_HART_LIST*
+==== Service: *CPPC_GET_HART_LIST*
 This service gets the list of a hart with a specified hart ID start index.
 
 [#table_cppc_gethartlist_request_data]

--- a/src/srvgrp-device-power.adoc
+++ b/src/srvgrp-device-power.adoc
@@ -44,18 +44,18 @@ corresponding to that state.
 .Device Power Services
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
-| Service ID	| Service Name 		| Request Type
-| 0x01		| ENABLE_NOTIFICATION	| NORMAL_REQUEST
-| 0x02		| GET_NUM_DOMAINS	| NORMAL_REQUEST
-| 0x03		| GET_DOMAIN_ATTRIBUTES	| NORMAL_REQUEST
-| 0x04		| SET_DOMAIN_STATE	| NORMAL_REQUEST
-| 0x05		| GET_DOMAIN_STATE	| NORMAL_REQUEST
+| Service ID	| Service Name 			| Request Type
+| 0x01		| DPWR_ENABLE_NOTIFICATION	| NORMAL_REQUEST
+| 0x02		| DPWR_GET_NUM_DOMAINS		| NORMAL_REQUEST
+| 0x03		| DPWR_GET_ATTRIBUTES		| NORMAL_REQUEST
+| 0x04		| DPWR_SET_STATE		| NORMAL_REQUEST
+| 0x05		| DPWR_GET_STATE		| NORMAL_REQUEST
 |===
 
 ==== Device Power Notifications
 This service group does not support any event for notification.
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *DPWR_ENABLE_NOTIFICATION*
 This service allows the AP to subscribe to Device Power service group notifications.
 The platform can optionally support notifications of events that may occur in the platform.
 The PuC can send these notification messages to the AP if they are implemented
@@ -87,7 +87,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_NUM_DOMAINS*
+==== Service: *DPWR_GET_NUM_DOMAINS*
 This service is used to query the number of device power domains available which
 can be controlled by the client. The number of domains returned can be less than
 the actual number of domains present with the platform.
@@ -112,7 +112,7 @@ the actual number of domains present with the platform.
 |===
 
 
-==== Service: *GET_DOMAIN_ATTRIBUTES*
+==== Service: *DPWR_GET_ATTRIBUTES*
 This service is used to query the attributes of a device power domain.
 
 [#table_devpower_getattrs_request_data]
@@ -144,7 +144,7 @@ name, a NULL-terminated ASCII string up to 16-bytes.
 |===
 
 
-==== Service: *SET_DOMAIN_STATE*
+==== Service: *DPWR_SET_STATE*
 This service is used to change the power state of a device power domain.
 
 [#table_devpower_setstate_request_data]
@@ -177,7 +177,7 @@ See Power States description in the <<table_devpower_powerstate_data>>.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_DOMAIN_STATE*
+==== Service: *DPWR_GET_STATE*
 This service is used to get the current power state of a device power domain.
 
 [#table_devpower_getstate_request_data]

--- a/src/srvgrp-hart-state-management.adoc
+++ b/src/srvgrp-hart-state-management.adoc
@@ -8,21 +8,21 @@ Below table lists the services in this group:
 .Hart State Management Services
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
-| Service ID	| Service Name 		| Request Type
-| 0x01		| ENABLE_NOTIFICATION	| NORMAL_REQUEST
-| 0x02		| HART_START		| NORMAL_REQUEST
-| 0x03		| HART_STOP		| NORMAL_REQUEST
-| 0x04		| HART_SUSPEND		| NORMAL_REQUEST
-| 0x05		| GET_HART_STATUS	| NORMAL_REQUEST
-| 0x06		| GET_HART_LIST		| NORMAL_REQUEST
-| 0x07		| GET_SUSPEND_TYPES	| NORMAL_REQUEST
-| 0x08		| GET_SUSPEND_INFO	| NORMAL_REQUEST
+| Service ID	| Service Name 			| Request Type
+| 0x01		| HSM_ENABLE_NOTIFICATION	| NORMAL_REQUEST
+| 0x02		| HSM_HART_START		| NORMAL_REQUEST
+| 0x03		| HSM_HART_STOP			| NORMAL_REQUEST
+| 0x04		| HSM_HART_SUSPEND		| NORMAL_REQUEST
+| 0x05		| HSM_GET_HART_STATUS		| NORMAL_REQUEST
+| 0x06		| HSM_GET_HART_LIST		| NORMAL_REQUEST
+| 0x07		| HSM_GET_SUSPEND_TYPES		| NORMAL_REQUEST
+| 0x08		| HSM_GET_SUSPEND_INFO		| NORMAL_REQUEST
 |===
 
 ==== Hart State Management Notifications
 This service group does not support any event for notification
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *HSM_ENABLE_NOTIFICATION*
 This service allows AP to subscribe to system reset service group notifications.
 Platform can optionally support notifications of events which might occur in the
 platform. PuC can send these notification messages to AP if they are implemented
@@ -53,7 +53,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *HART_START*
+==== Service: *HSM_HART_START*
 This service helps start (or power up) a hart with a specified hart-id. 
 Successful completion of this service means that hart with specified hart-id has
 started execution from the provided start address. The previous state of the 
@@ -86,14 +86,14 @@ Implementation should return proper error code in the status field accordingly.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *HART_STOP*
+==== Service: *HSM_HART_STOP*
 This service stops the calling hart. Mechanism to stop the hart is platform 
 specific. Hart can be powered down if supported or it can be put into a deepest 
 sleep state supported. Platform must acknowledge that hart can be stopped and 
 return success. Application Processor must execute WFI upon successful 
 acknowledgement. Platform then proceeds to stop the hart. Detecting the WFI 
 state from PuC is implementation defined. Once the hart is stopped it can only 
-be started using an explicit HART_START service call from the application 
+be started using an explicit HSM_HART_START service call from the application 
 processor.
 
 [#table_hsm_hartstop_request_data]
@@ -120,8 +120,8 @@ specific
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *HART_SUSPEND*
-This service puts the calling hart in suspended (or low power) state. Upon 
+==== Service: *HSM_HART_SUSPEND*
+This service puts the calling hart in suspended (or low power) state. Upon
 success, the calling hart is suspended only after it executes WFI instruction.
 
 [#table_hsm_hartsuspend_request_data]
@@ -153,7 +153,7 @@ _Only used for non-retentive suspend types._
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_HART_STATUS*
+==== Service: *HSM_GET_HART_STATUS*
 This service gets the running status of a Hart.
 
 [#table_hsm_gethartstatus_request_data]
@@ -191,7 +191,7 @@ This service gets the running status of a Hart.
 !===
 |===
 
-==== Service: *GET_HART_LIST*
+==== Service: *HSM_GET_HART_LIST*
 This service gets the list of harts with a specified Hart ID start index
 
 [#table_hsm_gethartlist_request_data]
@@ -222,7 +222,7 @@ This service gets the list of harts with a specified Hart ID start index
 | N+2	| HART_ID[N - 1] | uint32	| HART_ID
 |===
 
-==== Service: *GET_SUSPEND_TYPES*
+==== Service: *HSM_GET_SUSPEND_TYPES*
 This service gets a list of all supported suspend types. The system types in the
 list must be ordered based on increasing power savings.
 
@@ -256,7 +256,7 @@ items.
 | N+2	| SUSPEND_TYPE[N - 1]  | uint32	| Suspend Type
 |===
 
-==== Service: *GET_SUSPEND_INFO*
+==== Service: *HSM_GET_SUSPEND_INFO*
 Get attributes of a suspend type.
 
 [#table_hsm_getsuspendinfo_request_data]

--- a/src/srvgrp-management.adoc
+++ b/src/srvgrp-management.adoc
@@ -13,7 +13,7 @@ interfaces for invoking MM services synchronously.
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
 | Service ID	| Service Name 				| Request Type
-| 0x01		| ENABLE_NOTIFICATION			| NORMAL_REQUEST
+| 0x01		| MM_ENABLE_NOTIFICATION		| NORMAL_REQUEST
 | 0x02		| MM_VERSION				| NORMAL_REQUEST
 | 0x03		| MM_COMMUNICATE			| NORMAL_REQUEST
 | 0x04		| MM_COMPLETE				| NORMAL_REQUEST
@@ -23,7 +23,7 @@ interfaces for invoking MM services synchronously.
 ==== Management Notifications
 This service group does not support any event for notification.
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *MM_ENABLE_NOTIFICATION*
 This service allows AP to subscribe to management service group notifications.
 Platform can optionally support notifications of events which might occur in 
 the platform. PuC can send these notification messages to AP if they are 

--- a/src/srvgrp-performance.adoc
+++ b/src/srvgrp-performance.adoc
@@ -34,15 +34,15 @@ These operations are described in more detail in the following section.
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
 | Service ID	| Service Name 				| Request Type
-| 0x01		| ENABLE_NOTIFICATION			| NORMAL_REQUEST
-| 0x02		| GET_PERF_DOMAINS			| NORMAL_REQUEST
-| 0x03		| GET_PERF_DOMAIN_ATTRIBUTES		| NORMAL_REQUEST
-| 0x04		| GET_PERF_DOMAIN_LEVELS		| NORMAL_REQUEST
-| 0x05		| GET_PERF_LEVEL			| NORMAL_REQUEST
-| 0x06		| SET_PERF_LEVEL			| NORMAL_REQUEST
-| 0x07		| GET_PERF_LIMIT			| NORMAL_REQUEST
-| 0x08		| SET_PERF_LIMIT			| NORMAL_REQUEST
-| 0x09		| GET_PERF_FAST_CHANNEL_ATTRIBUTES	| NORMAL_REQUEST
+| 0x01		| PERF_ENABLE_NOTIFICATION		| NORMAL_REQUEST
+| 0x02		| PERF_GET_NUM_DOMAINS			| NORMAL_REQUEST
+| 0x03		| PERF_GET_ATTRIBUTES			| NORMAL_REQUEST
+| 0x04		| PERF_GET_SUPPORTED_LEVELS		| NORMAL_REQUEST
+| 0x05		| PERF_GET_LEVEL			| NORMAL_REQUEST
+| 0x06		| PERF_SET_LEVEL			| NORMAL_REQUEST
+| 0x07		| PERF_GET_LIMIT			| NORMAL_REQUEST
+| 0x08		| PERF_SET_LIMIT			| NORMAL_REQUEST
+| 0x09		| PERF_GET_FAST_CHANNEL_ATTRIBUTES	| NORMAL_REQUEST
 |===
 
 ==== Performance Notifications
@@ -92,10 +92,10 @@ for Performance service group.
 
 *Supported Services*::
 The Fast-channel currently supports only the following Performance services:
-* GET_PERF_LEVEL
-* SET_PERF_LEVEL
-* GET_PERF_LIMIT
-* SET_PERF_LIMIT
+* PERF_GET_LEVEL
+* PERF_SET_LEVEL
+* PERF_GET_LIMIT
+* PERF_SET_LIMIT
 
 
 *Platform Dependency*::
@@ -107,16 +107,16 @@ The Fast-channel currently supports only the following Performance services:
 *Discovering Fast-channels*::
 * Fast-channels support are discoverable through Performance service calls.
 * To determine if a platform supports Fast-channel for a specific performance
-  domain, use the `GET_PERF_DOMAIN_ATTRIBUTES` service call.
+  domain, use the `PERF_GET_ATTRIBUTES` service call.
 * If Fast-channel support is available, retrieve Fast-channel attributes for
-  specific Performance service call using the `GET_PERF_FAST_CHANNEL_ATTRIBUTES`
+  specific Performance service call using the `PERF_GET_FAST_CHANNEL_ATTRIBUTES`
   service call.
 
 
 *Doorbell Support*::
-* Doorbell support is not available for `GET_PERF_LEVEL` and `GET_PERF_LIMIT`
+* Doorbell support is not available for `PERF_GET_LEVEL` and `PERF_GET_LIMIT`
   service calls.
-* When Fast-channels are implemented for `GET_PERF_LEVEL` and `GET_PERF_LIMIT`
+* When Fast-channels are implemented for `PERF_GET_LEVEL` and `PERF_GET_LIMIT`
   service calls, the last known valid performance level or performance limits
   are always accessible via the Fast-channel without requiring a doorbell
   trigger.
@@ -129,11 +129,11 @@ The Fast-channel currently supports only the following Performance services:
   parameters and exclude the DOMAIN_ID. Given that a Fast-channel is specific
   to both DOMAIN_ID and SERVICE_ID, there is no requirement to include
   DOMAIN_ID or any other channel specific and message specific headers when
-  utilizing a Fast-channel. For instance, the payload of the `SET_PERF_LIMIT`
+  utilizing a Fast-channel. For instance, the payload of the `PERF_SET_LIMIT`
   message should be represented as `'uint32 MAX_PERF_LEVEL'` and
   `'uint32 MIN_PERF_LEVEL'`.
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *PERF_ENABLE_NOTIFICATION*
 This service is to enable or disable the performance changed notification event.
 This notification is sent from the PuC when the performance level, performance 
 limit or performance power of a performance domain has changed. This allows the 
@@ -166,7 +166,7 @@ notification.
 |===
 
 
-==== Service: *GET_PERF_DOMAINS*
+==== Service: *PERF_GET_NUM_DOMAINS*
 This service returns the number of performance domains supported by the system.
 The number of performance domains can vary depending on the hardware platform 
 and implementation. In general, performance domains are used to group related 
@@ -195,7 +195,7 @@ important for optimizing system performance and power consumption.
 |===
 
 
-==== Service: *GET_PERF_DOMAIN_ATTRIBUTES*
+==== Service: *PERF_GET_ATTRIBUTES*
 This service is used to retrieve the attributes of a specific performance 
 domain. These attributes provide information about the performance capabilities 
 and constraints of the domain, such as the performance limit and performance 
@@ -253,7 +253,7 @@ pass between two consecutive requests, in microseconds (us).
 | 3:6	| PERF_DOMAIN_NAME | uint8[16]	| Performance domain name, a NULL-terminated ASCII string up to 16-bytes.
 |===
 
-==== Service: *GET_PERF_DOMAIN_LEVELS*
+==== Service: *PERF_GET_SUPPORTED_LEVELS*
 This service provides a list of the available performance levels or also called
 operating performance points (OPPs) for a specific performance domain. These
 represent different performance levels that can be set for the components in the
@@ -290,7 +290,7 @@ loop:
 The pseudocode above demonstrates the process for retrieving the level
 information for a specific performance domain. First, the number of
 performance levels is determined by checking the FLAGS[28:21] parameter
-returned by the GET_PERF_DOMAIN_ATTRIBUTES service.
+returned by the PERF_GET_ATTRIBUTES service.
 
 Total words required for the number of performance levels according to the
 format in one message cannot exceed the total words available in one message
@@ -346,8 +346,8 @@ platform.
 |===
 
 
-==== Service: *GET_PERF_LEVEL*
-This service is used to obtain the current performance level of a specific 
+==== Service: *PERF_GET_LEVEL*
+This service is used to obtain the current performance level of a specific
 performance domain in the system.
 
 [#table_perf_getlevel_request_data]
@@ -375,7 +375,7 @@ performance domain in the system.
 |===
 
 
-==== Service: *SET_PERF_LEVEL*
+==== Service: *PERF_SET_LEVEL*
 This service is used to set the current performance level of a specific 
 performance domain in the system.
 
@@ -409,7 +409,7 @@ performance level.
 |===
 
 
-==== Service: *GET_PERF_LIMIT*
+==== Service: *PERF_GET_LIMIT*
 This service is used to obtain the current performance limit of a specific 
 performance domain in the system.
 
@@ -439,7 +439,7 @@ performance domain in the system.
 |===
 
 
-==== Service: *SET_PERF_LIMIT*
+==== Service: *PERF_SET_LIMIT*
 This service is used to set the current performance limit of a specific 
 performance domain in the system.
 
@@ -474,7 +474,7 @@ performance level.
 |===
 
 
-==== Service: *GET_PERF_FAST_CHANNEL_ATTRIBUTES*
+==== Service: *PERF_GET_FAST_CHANNEL_ATTRIBUTES*
 This service allows clients to query attributes of the Fast-channel for a specific performance domain and performance service.
 
 [#table_perf_getfastchanaddr_request_data]

--- a/src/srvgrp-system-reset.adoc
+++ b/src/srvgrp-system-reset.adoc
@@ -21,15 +21,15 @@ Below table lists the services in this group:
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
 | Service ID	| Service Name 			| Request Type
-| 0x01		| ENABLE_NOTIFICATION		| NORMAL_REQUEST
-| 0x02		| GET_SYSTEM_RESET_ATTRIBUTES	| NORMAL_REQUEST
-| 0x03		| SYSTEM_RESET			| POSTED_REQUEST
+| 0x01		| SYSRST_ENABLE_NOTIFICATION	| NORMAL_REQUEST
+| 0x02		| SYSRST_GET_ATTRIBUTES		| NORMAL_REQUEST
+| 0x03		| SYSRST_RESET			| POSTED_REQUEST
 |===
 
 ==== System Reset Notifications
 This service group does not support any event for notifications.
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *SYSRST_ENABLE_NOTIFICATION*
 This service allows AP to subscribe to system reset service group notifications.
 Platform can optionally support notifications of events which might occur in the
 platform. PuC can send these notification messages to AP if they are 
@@ -60,7 +60,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_SYSTEM_RESET_ATTRIBUTES*
+==== Service: *SYSRST_GET_ATTRIBUTES*
 This service is used to discover system reset types supported by the platform. 
 *System Shutdown* and *System Cold Reset* are mandatory and assumed to be 
 supported. *System Warm Reset* is a qualified reset type which can be discovered
@@ -107,7 +107,7 @@ required.
 !===
 |===
 
-==== Service: *SYSTEM_RESET*
+==== Service: *SYSRST_RESET*
 This service is used to initiate the system shutdown or reset the system with 
 the provided type.
 *System Shutdown* and *System Cold Reset* are supported implicitly but 

--- a/src/srvgrp-system-suspend.adoc
+++ b/src/srvgrp-system-suspend.adoc
@@ -10,15 +10,15 @@ Below if the list of services in this group:
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
 | Service ID	| Service Name 			| Request Type
-| 0x01		| ENABLE_NOTIFICATION		| NORMAL_REQUEST
-| 0x02		| GET_SYSTEM_SUSPEND_ATTRIBUTES	| NORMAL_REQUEST
-| 0x03		| SYSTEM_SUSPEND		| NORMAL_REQUEST
+| 0x01		| SYSSUSP_ENABLE_NOTIFICATION	| NORMAL_REQUEST
+| 0x02		| SYSSUSP_GET_ATTRIBUTES	| NORMAL_REQUEST
+| 0x03		| SYSSUSP_SUSPEND		| NORMAL_REQUEST
 |===
 
 ==== System Suspend Notifications
 This service group does not support any event for notification.
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *SYSSUSP_ENABLE_NOTIFICATION*
 This service allows AP to subscribe to system reset service group notifications.
 Platform can optionally support notifications of events which might occur in the platform. PuC can send these notification messages to AP if they are implemented
 and AP has subscribed to these. Events supported are described above in System
@@ -48,7 +48,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_SYSTEM_SUSPEND_ATTRIBUTES*
+==== Service: *SYSSUSP_GET_ATTRIBUTES*
 This service is used to discover system suspend types supported by the platform.
 Each supported system suspend type is identified by SUSPEND_TYPE.
 
@@ -95,7 +95,7 @@ Each supported system suspend type is identified by SUSPEND_TYPE.
 !===
 |===
 
-==== Service: *SYSTEM_SUSPEND*
+==== Service: *SYSSUSP_SUSPEND*
 This service puts the system into low power state based on the specified suspend
 type. The service requires all harts except the calling hart to be in STOPPED 
 state as defined by the Hart State Management service group. The system goes 
@@ -129,7 +129,7 @@ executes WFI instruction.
 !===
 ! *Error Code* 	!  *Description*
 ! RPMI_ERROR_NOT_SUPPORTED ! SUSPEND_TYPE not supported. AP must use the
-GET_SYSTEM_SUSPEND_ATTRIBUTES service to discover if SUSPEND_TYPE is supported
+SYSSUSP_GET_ATTRIBUTES service to discover if SUSPEND_TYPE is supported
 or not. Only supported SUSPEND_TYPE must be used with this service.
 !===
 - Other errors <<table_error_codes>>

--- a/src/srvgrp-voltage.adoc
+++ b/src/srvgrp-voltage.adoc
@@ -12,21 +12,21 @@ Below table lists the services in this group:
 .Voltage Services
 [cols="1, 3, 2", width=100%, align="center", options="header"]
 |===
-| Service ID	| Service Name 		| Request Type
-| 0x01		| ENABLE_NOTIFICATION	| NORMAL_REQUEST
-| 0x02		| GET_NUM_DOMAINS	| NORMAL_REQUEST
-| 0x03		| GET_DOMAIN_ATTRIBUTES	| NORMAL_REQUEST
-| 0x04		| GET_DOMAIN_LEVELS	| NORMAL_REQUEST
-| 0x05		| SET_DOMAIN_CONFIG	| NORMAL_REQUEST
-| 0x06		| GET_DOMAIN_CONFIG	| NORMAL_REQUEST
-| 0x07		| SET_DOMAIN_LEVEL	| NORMAL_REQUEST
-| 0x08		| GET_DOMAIN_LEVEL	| NORMAL_REQUEST
+| Service ID	| Service Name 			| Request Type
+| 0x01		| VOLT_ENABLE_NOTIFICATION	| NORMAL_REQUEST
+| 0x02		| VOLT_GET_NUM_DOMAINS		| NORMAL_REQUEST
+| 0x03		| VOLT_GET_ATTRIBUTES		| NORMAL_REQUEST
+| 0x04		| VOLT_GET_SUPPORTED_LEVELS	| NORMAL_REQUEST
+| 0x05		| VOLT_SET_CONFIG		| NORMAL_REQUEST
+| 0x06		| VOLT_GET_CONFIG		| NORMAL_REQUEST
+| 0x07		| VOLT_SET_LEVEL		| NORMAL_REQUEST
+| 0x08		| VOLT_GET_LEVEL		| NORMAL_REQUEST
 |===
 
 ==== Voltage Notifications
 This service group does not support any event for notification.
 
-==== Service: *ENABLE_NOTIFICATION*
+==== Service: *VOLT_ENABLE_NOTIFICATION*
 This service allows the AP to subscribe to voltage service group notifications.
 The platform can optionally support notifications of events which might occur in the platform.
 The PuC can send these notification messages to the AP if they are implemented
@@ -58,7 +58,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_NUM_DOMAINS*
+==== Service: *VOLT_GET_NUM_DOMAINS*
 Request for the number of voltage domains available in the system.
 
 [#table_voltage_getnumdomains_request_data]
@@ -81,7 +81,7 @@ as NUM_DOMAINS.
 | 1	|	NUM_DOMAINS 	| uint32 	| Number of voltage domains
 |===
 
-==== Service: *GET_DOMAIN_ATTRIBUTES*
+==== Service: *VOLT_GET_ATTRIBUTES*
 Each domain may support multiple voltage levels, which are permitted by the domain
 for operation. For each domain, this message returns a domain name, represented as
 a NULL-terminated ASCII string of 16 bytes. The number of levels indicates the total
@@ -147,7 +147,7 @@ field in FLAGS.
 | 4:7	| VOLTAGE_DOMAIN_NAME	| uint8[16]	| Voltage domain name, a NULL-terminated ASCII string up to 16-bytes.
 |===
 
-==== Service: *GET_DOMAIN_LEVELS*
+==== Service: *VOLT_GET_SUPPORTED_LEVELS*
 Each domain may support multiple voltage levels which are allowed by the domain 
 to operate.
 Depending on the hardware, the voltage levels can be either discrete or stepwise range.
@@ -194,20 +194,20 @@ all the voltage levels.
 | 4	| VOLTAGE[0]	| int32	| Voltage array where each entry in the
 array is a voltage level in microvolts (uV).
 
-N is specified by the GET_DOMAIN_ATTRIBUTES.NUM_LEVELS. Voltage represented in 
+N is specified by the VOLT_GET_ATTRIBUTES.NUM_LEVELS. Voltage represented in 
 microvolt (uV).
 
-If the bits in GET_DOMAIN_ATTRIBUTES.FLAGS[31:30] are set to `0` (Fixed voltage), VOLTAGE[0]
+If the bits in VOLT_GET_ATTRIBUTES.FLAGS[31:30] are set to `0` (Fixed voltage), VOLTAGE[0]
 contains a fixed voltage level in the array. +
 `VOLTAGE[0]: volt_uV`
 
-If the bits in GET_DOMAIN_ATTRIBUTES.FLAGS[31:30] are set to `1` (Simple-linear), it means that
+If the bits in VOLT_GET_ATTRIBUTES.FLAGS[31:30] are set to `1` (Simple-linear), it means that
 the voltage array contains three entries as below: +
 `VOLTAGE[0]: min_uV +
 VOLTAGE[1]: max_uV +
 VOLTAGE[2]: step_uV`
  
-If the bits in GET_DOMAIN_ATTRIBUTES.FLAGS[31:30] are set to `2` (Multi-linear), it indicates
+If the bits in VOLT_GET_ATTRIBUTES.FLAGS[31:30] are set to `2` (Multi-linear), it indicates
 that the voltage array contains multiple groups of four entries. Each group 
 represent a linear voltage range and consists of the following entries: +
 `VOLTAGE[0] = min_uV +
@@ -215,7 +215,7 @@ VOLTAGE[1] = min_sel +
 VOLTAGE[2] = max_sel +
 VOLTAGE[3] = step_uV`
 
-If the bits in  GET_DOMAIN_ATTRIBUTES.FLAGS[31:30] are set to 3 (Discrete), it means that
+If the bits in  VOLT_GET_ATTRIBUTES.FLAGS[31:30] are set to 3 (Discrete), it means that
 the entry array contains discrete voltage levels listed in ascending numeric 
 order (_Low index represents minimum voltage level, and high index represents
 maximum voltage level supported_). +
@@ -227,7 +227,7 @@ VOLTAGE[N - 1]: Voltage(N – 1)`
 | ...	| VOLTAGE[N-1]	| int32	|
 |===
 
-==== Service: *SET_DOMAIN_CONFIG*
+==== Service: *VOLT_SET_CONFIG*
 Set voltage config message enable or disable any voltage domain. Enabling the voltage
 means applying the domain with the voltage level to operate normally. The AP can
 enable the voltage to any domain without knowing the actual voltage levels. 
@@ -271,7 +271,7 @@ specified voltage domain.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *GET_DOMAIN_CONFIG*
+==== Service: *VOLT_GET_CONFIG*
 Get voltage config message request for the configuration of the voltage domain 
 currently set.
 [#table_voltage_getdomainconfig_request_data]
@@ -305,7 +305,7 @@ currently set.
 |===
 
 
-==== Service: *SET_DOMAIN_LEVEL*
+==== Service: *VOLT_SET_LEVEL*
 Set the voltage level in microvolts (uV) of a voltage domain.
 
 [#table_voltage_setdomainlevel_request_data]
@@ -335,7 +335,7 @@ voltage domain.
 |===
 
 
-==== Service: *GET_DOMAIN_LEVEL*
+==== Service: *VOLT_GET_LEVEL*
 Get the current voltage level in microvolts (uV) of a voltage domain.
 
 [#table_voltage_getdomainlevel_request_data]


### PR DESCRIPTION
Add prefix to all services to easily differentiate similar service name from different service group.