### PR TITLE
Add RAS_AGENT Service Group

### DIFF
--- a/riscv-rpmi.adoc
+++ b/riscv-rpmi.adoc
@@ -84,6 +84,8 @@ include::src/srvgrp-performance.adoc[]
 
 include::src/srvgrp-management.adoc[]
 
+include::src/srvgrp-ras-agent.adoc[]
+
 // The index must precede the bibliography
 //include::src/index.adoc[]
 include::src/bibliography.adoc[]

--- a/src/srvgrp-ras-agent.adoc
+++ b/src/srvgrp-ras-agent.adoc
@@ -1,0 +1,199 @@
+:path: src/
+:imagesdir: ../images
+
+ifdef::rootpath[]
+:imagesdir: {rootpath}{path}{imagesdir}
+endif::rootpath[]
+
+ifndef::rootpath[]
+:rootpath: ./../
+endif::rootpath[]
+
+===  Service Group - *RAS_AGENT* (servicegroup_id: 0x0000B)
+The RAS agent service group provides services to enumerate various error
+sources in a system and to get their descriptors. These services are provided
+by RAS Agent.
+
+Each error source in a system has a unique 32-bit identification number called
+as `RAS_ERR_SRC_ID`.
+
+Below table lists the services in this group:
+[#table_ras_agent_services]
+.RAS Agent Services
+[cols="1, 3, 2", width=100%, align="center", options="header"]
+|===
+| Service ID	| Service Name 			| Request Type
+| 0x01		| RAS_ENABLE_NOTIFICATION	| NORMAL_REQUEST
+| 0x02		| RAS_GET_NUM_ERR_SRCS		| NORMAL_REQUEST
+| 0x03		| RAS_GET_ERR_SRCS_ID_LIST	| NORMAL_REQUEST
+| 0x04		| RAS_GET_ERR_SRC_DESC		| NORMAL_REQUEST
+|===
+
+[#ras-notifications]
+==== Notifications
+This service group does not support any event for notification.
+
+==== Service: *RAS_ENABLE_NOTIFICATION*
+This service allows the AP to subscribe to RAS_AGENT service group
+notifications. The platform can optionally support notifications of events that
+may occur in the platform. The PuC can send these notification messages to the
+AP if they are implemented and the AP has subscribed to them. The supported
+events are described in <<ras-notifications>>.
+
+[#table_ras_ennotification_request_data]
+.Request Data
+[cols="1, 2, 1, 7", width=100%, align="center", options="header"]
+|===
+| Word	| Name 		| Type		| Description
+| 0	| EVENT_ID	| uint32	| Event to be subscribed for 
+notification.
+|===
+
+[#table_ras_ennotification_response_data]
+.Response Data
+[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word	| Name 		| Type		| Description
+| 0	| STATUS	| int32		| Return Status Code
+[cols="5,5"]
+!===
+! *Error Code* 	!  *Description*
+! RPMI_SUCCESS	! Notifications are subscribed successfully.
+! RPMI_ERROR_NOT_FOUND ! EVENT_ID is not supported or invalid.
+! RPMI_ERROR_NOT_SUPPORTED ! Notifications not supported.
+!===
+- Other errors <<table_error_codes>>
+|===
+
+==== Service: *RAS_GET_NUM_ERR_SRCS*
+This service is used to query number of error sources available in the system.
+
+[#table_ras_agent_getnum_err_srcs_request_data]
+.Request Data
+- NA
+
+[#table_ras_agent_getnum_err_srcs_response_data]
+.Response Data
+[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word	| Name 		| Type		| Description
+| 0	| STATUS	| int32		| Return status code
+[cols="2,5"]
+!===
+! *Error Code* 	!  *Description*
+! RPMI_SUCCESS	! Service completed successfully and number of error sources
+returned as NUM_ERR_SRCS.
+!===
+- Other errors <<table_error_codes>>
+| 1	|	NUM_ERR_SRCS 	| uint32 	| Number of error sources
+|===
+
+==== Service: *RAS_GET_ERR_SRCS_ID_LIST*
+This service returns a list of `RAS_ERR_SRC_ID` for all error soruces present
+in the system. The `RAS_ERR_SRC_ID` can be used to get the associated
+descriptor of the error source.
+
+[#table_ras_agent_get_err_srcs_id_list_request_data]
+.Request Data
+[cols="1, 3, 1, 7", width=100%, align="center", options="header"]
+|===
+| Word	| Name 		| Type		| Description
+| 0	| START_INDEX	| uint32	| Starting index of `RAS_ERR_SRC_ID` list. +
+`0` for the first call, subsequent calls will use the next index of the +
+remaining items.
+|===
+
+[#table_ras_agent_get_err_srcs_id_list_response_data]
+.Response Data
+[cols="1, 3, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word	| Name 		| Type		| Description
+| 0	| STATUS	| int32		| Return Status Code
+[cols="7,5"]
+!===
+! *Error Code* 	!  *Description*
+! RPMI_SUCCESS	! Service completed successfully and list of error sources
+returned
+! RPMI_ERROR_INVALID_PARAMETER	! START_INDEX is not valid
+!===
+- Other errors <<table_error_codes>>
+| 1	| FLAGS		| uint32	| _Reserved_ and must be `0`.
+| 2	| REMAINING	| uint32	| Remaining number of error source IDs
+| 3	| RETURNED	| uint32	| Number of error source IDs returned +
+	in this request
+| 4	| RAS_ERR_SRC_ID[N]	| uint32	| An array of error source IDs where +
+	each entry in the
+array is a unique error source ID.
+
+N is equal to `RETURNED` number of error source IDs in this request +
+|===
+
+==== Service: *RAS_GET_ERR_SRC_DESC*
+This service returns the error source descriptor of an error source specified
+by `RAS_ERR_SRC_ID`.
+
+[#table_ras_agent_get_err_src_desc_request_data]
+[cols="1, 2, 1, 7", width=100%, align="center", options="header"]
+|===
+| Word	| Name 		| Type		| Description
+| 0	| RAS_ERR_SRC_ID	| uint32	| Error source ID for which attributes +
+	are to be returned
+| 1	| BYTE_OFFSET	| uint32	| Offset from which the descriptor is +
+	to be read. Offset `0` for the first call, subsequent byte offset of +
+	the remaining bytes.
+|===
+
+[#table_ras_agent_get_err_src_desc_response_data]
+.Response Data
+[cols="1, 3, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word	| Name 		| Type		| Description
+| 0	| STATUS	| int32		| Return Status Code
+[cols="7,5"]
+!===
+! *Error Code* 	!  *Description*
+! RPMI_SUCCESS	! Service completed successfully and partial/complete error +
+	source descriptor returned.
+! RPMI_ERROR_NOT_FOUND ! Error source with ID `RAS_ERR_SRC_ID` not found
+! RPMI_ERROR_INVALID_PARAMETER	! `BYTE_OFFSET` is not valid
+!===
+- Other errors <<table_error_codes>>
+| 1	| FLAGS		| uint32	| [cols="2,5a"]
+!===
+! *Bits* 	!  *Description*
+! [3:0]		! Format of the error source descriptor. +
+	Value `0` indicates that the error source descriptor is in GHESv2 format. +
+	Rest of the values (1-15) are implementation specific.
+! [31:4]	! _Reserved_
+!===
+| 2	| REMAINING	| uint32	| Remaining number of bytes to be read
+| 3	| RETURNED	| uint32	| Number of bytes read in this request
+| 4	| ERR_SRC_DESC[N]	| uint8	| Full or partial descriptor +
+	N is equal to the `RETURNED` bytes in this request.
+|===
+
+==== Error Source Descriptor Format
+===== ACPI Systems
+For systems that support ACPI/APEI, the format of the error source descriptor
+is as defined in ACPI specification v6.4 or above, (GHESv2) cite:[ACPI].
+If the value of `RAS_GET_ERR_SRC_DESC.FLAGS[3:0]` is `0`, it indicates that the
+error source descriptor format is GHESv2.
+
+The RAS agent populates the error source descriptor fields according to the
+error source specified by `RAS_ERR_SRC_ID`.
+
+NOTE: The error source descriptor has an `error_status_structure` field which
+is a generic address structure (`GAS`) as defined in ACPI v6.4 (GHESv2)
+cite:[ACPI]. This field specifies the location of a register that contains the
+physical address of a block of memory that holds the error status data for the
+specified error source. This block of memory is referred to as
+`error_status_block`. The allocation of `error_status_block` is platform
+dependent and is done by the RAS agent. The physical address of
+`error_status_block` is stored in the `error_status_structure` field of the
+error source descriptor being returned.
+
+===== Non-ACPI Systems
+RAS is not standardized for non-ACPI systems. Such systems may define custom
+format for an error source descriptor. The type of custom error source
+descriptor format can be read from `RAS_GET_ERR_SRC_DESC.FLAGS[3:0]`. The
+values from 1 to 15 are reserved for custom format types.


### PR DESCRIPTION
In ACPI systems, The RAS_AGENT works as a bridge
between the RISCV RERI compliant error sources in
the system and the APEI tables. One of its job is
the populate CPER records when errors occur.

The RAS_AGENT has complete knowledge of the error
sources present in the system and errors they can
generate. The services in the RAS_AGENT service group respond to
- Enumeration of various error sources present in the system
- Get the error source descriptor for an error source

These services from RAS_AGENT can be used to populate the HEST table when ACPI tables are being generated.

For non-ACPI systems also, the error sources can be enumerated. The format for the error source descriptor is left to the implementation.

Signed-off-by: Himanshu Chauhan <hchauhan@ventanamicro.com>