### PR TITLE
Fix format new

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = RISC-V RPMI Specification
 
 RPMI (RISC-V Platform Management Interface) is an extensible messaging 
-interface between Application Processors and Platform Microcontrollers for
+interface between application processors and platform microcontrollers for
 management and control of system.
 
 This specification is based on an earlier draft located here:

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -53,10 +53,6 @@ services within.
 In addition to the standard services, RPMI can also be extended to allow vendors
 to add their own services.
 
-The term "Application Processor" or "AP" is used interchangeably throughout this
-document. Similarly, the term "Platform Microcontroller" or "PuC" is used
-interchangeably.
-
 .High Level Architecture
 image::highlevel-arch.png[width=800,height=800, align="center"]
 

--- a/src/srvgrp-clock.adoc
+++ b/src/srvgrp-clock.adoc
@@ -15,8 +15,8 @@ this group are used to enable or disable clocks, and to set/get clock rates.
 
 Each clock in the system is identified by the clock ID, which is an integer
 identifier assigned to each clock. The mapping of CLOCK_ID and clock is known
-to both the AP and the Platform Microcontroller. Clock ID identifiers are
-sequential and starting from `0`.
+to both the application processor and the platform microcontroller. Clock ID
+identifiers are sequential and starting from `0`.
 
 The device or the group of devices sharing the same clock source form a
 single clock domain, which is identified by the CLOCK_ID. Any change to the
@@ -72,11 +72,12 @@ Below table lists the services in this group:
 This service group does not support any event for notification
 
 ==== Service: *CLK_ENABLE_NOTIFICATION*
-This service allows the AP to subscribe to CLOCK service group notifications.
-The platform can optionally support notifications of events which might occur in
-the platform. The PuC can send these notification messages to AP if they are
-implemented and the AP has subscribed to these. The supported events are described
-in <<clock-notifications>>.
+This service allows the application processor to subscribe to CLOCK service
+group notifications. The platform can optionally support notifications of
+events which might occur in the platform. The platform microcontroller can send
+these notification messages to application processor if they are implemented
+and the application processor has subscribed to these. The supported events are
+described in <<clock-notifications>>.
 
 [#table_clock_ennotification_request_data]
 .Request Data
@@ -189,14 +190,15 @@ the lower index in the CLOCK_RATE field. If the CLOCK_FORMAT is a linear range,
 then the CLOCK_RATE array contains a triplet of `(min_Hz, max_Hz, step_Hz)` where
 each item in the triplet is a clock rate value.
 
-Total words required for the number of clock rates according to the format in
-one message cannot exceed the total words available in one message DATA field.
-If they exceed then the PuC will return the number of clock rates which can be
-accommodated in one message and set the REMAINING field accordingly. The AP,
-when REMAINING field is not `0` must call this service again with appropriate
-CLOCK_RATE_INDEX set to get the remaining clock rates. It's possible that
-multiple service calls may be required to get all the clock rates.
-In case the CLOCK_FORMAT is a linear range the RETURNED field will be set to `3`.
+Total words required for the number of clock rates according to the format in 
+one message cannot exceed the total words available in one message DATA field. 
+If they exceed then the platform microcontroller will return the number of
+clock rates which can be accommodated in one message and set the REMAINING field
+accordingly. The application processor, when REMAINING field is not `0` must
+call this service again with appropriate CLOCK_RATE_INDEX set to get the
+remaining clock rates. It's possible that multiple service calls may be required
+to get all the clock rates. In case the CLOCK_FORMAT is a linear range the
+RETURNED field will be set to `3`.
 
 [#table_clock_getsupprates_request_data]
 .Request Data

--- a/src/srvgrp-clock.adoc
+++ b/src/srvgrp-clock.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - *CLOCK* (servicegroup_id: 0x00007)
+===  Service Group - *CLOCK* (SERVICEGROUP_ID: 0x00007)
 This service group is for the management of system clocks. Services defined in
 this group are used to enable or disable clocks, and to set/get clock rates.
 
@@ -71,7 +71,7 @@ Below table lists the services in this group:
 ==== Notifications
 This service group does not support any event for notification
 
-==== Service: *CLK_ENABLE_NOTIFICATION*
+==== Service: CLK_ENABLE_NOTIFICATION (SERVICE_ID: 0x01)
 This service allows the application processor to subscribe to CLOCK service
 group notifications. The platform can optionally support notifications of
 events which might occur in the platform. The platform microcontroller can send
@@ -104,7 +104,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *CLK_GET_NUM_CLOCKS*
+==== Service: CLK_GET_NUM_CLOCKS (SERVICE_ID: 0x02)
 This service is used to query the number of clocks available in the system.
 All supported clocks in the system are designated by an integer identifier
 called CLOCK_ID. CLOCK_ID are sequential starting from `0`.
@@ -128,7 +128,7 @@ called CLOCK_ID. CLOCK_ID are sequential starting from `0`.
 | 1	|	NUM_CLOCKS	| uint32 	| Number of Clocks
 |===
 
-==== Service: *CLK_GET_ATTRIBUTES*
+==== Service: CLK_GET_ATTRIBUTES (SERVICE_ID: 0x03)
 This service provides detailed attributes of a clock, including its name,
 represented as a 16-byte array of ASCII strings. It also specifies the
 transition latency, which denotes the maximum time for the clock to stabilize
@@ -178,7 +178,7 @@ the future, as needed.
 | 4:7	| CLOCK_NAME		| uint8[16]	| Clock name
 |===
 
-==== Service: *CLK_GET_SUPPORTED_RATES*
+==== Service: CLK_GET_SUPPORTED_RATES (SERVICE_ID: 0x04)
 Each domain may support multiple clock rate values which are allowed by the
 domain to operate. Message can also pass the `CLOCK_RATE_INDEX` which is the index
 to the first rate value to be described in the return rate array. If all
@@ -229,7 +229,7 @@ RETURNED field will be set to `3`.
 | 4	| CLOCK_RATE[N]	| uint32[2] | Clock rate. (Refer to <<table_clock_rate>>)
 |===
 
-==== Service: *CLK_SET_CONFIG*
+==== Service: CLK_SET_CONFIG (SERVICE_ID: 0x05)
 Set clock config, enable or disable the clock.
 
 [#table_clock_setconfig_request_data]
@@ -267,7 +267,7 @@ Set clock config, enable or disable the clock.
 |===
 
 
-==== Service: *CLK_GET_CONFIG*
+==== Service: CLK_GET_CONFIG (SERVICE_ID: 0x06)
 Get the current status of a clock, if it's enabled or disabled.
 
 [#table_clock_getconfig_request_data]
@@ -300,7 +300,7 @@ Get the current status of a clock, if it's enabled or disabled.
 !===
 |===
 
-==== Service: *CLK_SET_RATE*
+==== Service: CLK_SET_RATE (SERVICE_ID: 0x07)
 Set clock rate.
 
 [#table_clock_setrate_request_data]
@@ -342,7 +342,7 @@ Set clock rate.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *CLK_GET_RATE*
+==== Service: CLK_GET_RATE (SERVICE_ID: 0x08)
 Get the current clock rate value.
 
 [#table_clock_getrate_request_data]

--- a/src/srvgrp-device-power.adoc
+++ b/src/srvgrp-device-power.adoc
@@ -71,11 +71,12 @@ and start from 0.
 This service group does not support any event for notification.
 
 ==== Service: *DPWR_ENABLE_NOTIFICATION*
-This service allows the AP to subscribe to DEVICE_POWER service group notifications.
-The platform can optionally support notifications of events that may occur in the platform.
-The PuC can send these notification messages to the AP if they are implemented
-and the AP has subscribed to them. The supported events are described in
-<<device-power-notifications>>.
+This service allows the application processor to subscribe to DEVICE_POWER
+service group notifications. The platform can optionally support notifications
+of events that may occur in the platform. The platform microcontroller can send
+these notification messages to the application processor if they are implemented
+and the application processor has subscribed to them. The supported events are
+described in <<device-power-notifications>>.
 
 [#table_devpower_ennotification_request_data]
 .Request Data

--- a/src/srvgrp-device-power.adoc
+++ b/src/srvgrp-device-power.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - *DEVICE_POWER* (servicegroup_id: 0x00008)
+===  Service Group - *DEVICE_POWER* (SERVICEGROUP_ID: 0x00008)
 This DEVICE_POWER service group provides messages to manage the power states of
 a device power domain. This service group is used only for device power
 management since System and CPU power management is handled by already defined
@@ -70,7 +70,7 @@ and start from 0.
 ==== Notifications
 This service group does not support any event for notification.
 
-==== Service: *DPWR_ENABLE_NOTIFICATION*
+==== Service: DPWR_ENABLE_NOTIFICATION (SERVICE_ID: 0x01)
 This service allows the application processor to subscribe to DEVICE_POWER
 service group notifications. The platform can optionally support notifications
 of events that may occur in the platform. The platform microcontroller can send
@@ -103,7 +103,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *DPWR_GET_NUM_DOMAINS*
+==== Service: DPWR_GET_NUM_DOMAINS (SERVICE_ID: 0x02)
 This service is used to query the number of device power domains available which
 can be controlled by the client. The number of domains returned can be less than
 the actual number of domains present with the platform.
@@ -128,7 +128,7 @@ the actual number of domains present with the platform.
 |===
 
 
-==== Service: *DPWR_GET_ATTRIBUTES*
+==== Service: DPWR_GET_ATTRIBUTES (SERVICE_ID: 0x03)
 This service is used to query the attributes of a device power domain.
 
 [#table_devpower_getattrs_request_data]
@@ -160,7 +160,7 @@ name, a NULL-terminated ASCII string up to 16-bytes.
 |===
 
 
-==== Service: *DPWR_SET_STATE*
+==== Service: DPWR_SET_STATE (SERVICE_ID: 0x04)
 This service is used to change the power state of a device power domain.
 
 [#table_devpower_setstate_request_data]
@@ -193,7 +193,7 @@ See Power States description in the <<table_devpower_powerstate_data>>.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *DPWR_GET_STATE*
+==== Service: DPWR_GET_STATE (SERVICE_ID: 0x05)
 This service is used to get the current power state of a device power domain.
 
 [#table_devpower_getstate_request_data]

--- a/src/srvgrp-management.adoc
+++ b/src/srvgrp-management.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - *MANAGEMENT_MODE* (servicegroup_id: 0x0000A)
+===  Service Group - *MANAGEMENT_MODE* (SERVICEGROUP_ID: 0x0000A)
 This MANAGEMENT_MODE service group is designed to be used for software invocation
 of Management Mode (MM) in a secure execution environment. For general background
 on Management Mode, refer to the Platform Initialization (PI) specifications
@@ -35,7 +35,7 @@ MM_COMPLETE facilitates synchronous call from the secure to the non-secure world
 ==== Notifications
 This service group does not support any event for notification.
 
-==== Service: *MM_ENABLE_NOTIFICATION*
+==== Service: MM_ENABLE_NOTIFICATION (SERVICE_ID: 0x01)
 This service allows the application processor to subscribe to MANAGEMENT_MODE
 service group notifications. Platform can optionally support notifications of
 events which might occur in the platform. Platform microcontroller can send
@@ -70,7 +70,7 @@ notification.
 
 
 
-==== Service: *MM_VERSION*
+==== Service: MM_VERSION (SERVICE_ID: 0x02)
 This service returns the version of a Management Mode.
 
 [#table_mm_version_request_data]
@@ -101,7 +101,7 @@ This service returns the version of a Management Mode.
 
 
 
-==== Service: *MM_COMMUNICATE*
+==== Service: MM_COMMUNICATE (SERVICE_ID: 0x03)
 Calling this MM_COMMUNICATE api invokes a MM service that is implemented in the
 secure execution environment. The MM_COMM_DATA contains data to identify and
 invoke the MM service. The readiness of this synchronous request from the non-secure
@@ -139,7 +139,7 @@ from non-secure to secure world.
 
 
 
-==== Service: *MM_COMPLETE*
+==== Service: MM_COMPLETE (SERVICE_ID: 0x04)
 Use this MM_COMPLETE as the “world-switch synchronous call” normally at the end
 of a synchronous MM_COMMUNICATE call to signal the readiness for handling the 
 synchronous request. The MM_COMM_DATA contains the returned data of the MM

--- a/src/srvgrp-management.adoc
+++ b/src/srvgrp-management.adoc
@@ -36,11 +36,12 @@ MM_COMPLETE facilitates synchronous call from the secure to the non-secure world
 This service group does not support any event for notification.
 
 ==== Service: *MM_ENABLE_NOTIFICATION*
-This service allows the AP to subscribe to MANAGEMENT_MODE service group
-notifications. Platform can optionally support notifications of events which
-might occur in the platform. PuC can send these notification messages to AP
-if they are implemented and AP has subscribed to these. Events supported are
-described in <<management-notifications>>.
+This service allows the application processor to subscribe to MANAGEMENT_MODE
+service group notifications. Platform can optionally support notifications of
+events which might occur in the platform. Platform microcontroller can send
+these notification messages to application processor if they are implemented
+and application processor has subscribed to these. Events supported are described
+in <<management-notifications>>.
 
 [#table_mm_ennotification_request_data]
 .Request Data

--- a/src/srvgrp-performance.adoc
+++ b/src/srvgrp-performance.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - *PERFORMANCE* (servicegroup_id: 0x00009)
+===  Service Group - *PERFORMANCE* (SERVICEGROUP_ID: 0x00009)
 This PERFORMANCE service group is designed for managing the performance of a
 group of devices or application processors that operate in the same performance
 domain. Unlike legacy performance control mechanisms where the OS was responsible
@@ -150,7 +150,7 @@ The Fast-channel currently supports only the following Performance services:
   message should be represented as `'uint32 MAX_PERF_LEVEL'` and
   `'uint32 MIN_PERF_LEVEL'`.
 
-==== Service: *PERF_ENABLE_NOTIFICATION*
+==== Service: PERF_ENABLE_NOTIFICATION (SERVICE_ID: 0x01)
 This service is to enable or disable the performance changed notification event.
 The notification is sent from the platform microcontroller when the performance
 level, performance limit or performance power of a performance domain has changed.
@@ -184,7 +184,7 @@ notification.
 |===
 
 
-==== Service: *PERF_GET_NUM_DOMAINS*
+==== Service: PERF_GET_NUM_DOMAINS (SERVICE_ID: 0x02)
 This service returns the number of performance domains supported by the system.
 The number of performance domains can vary depending on the hardware platform
 and implementation. In general, performance domains are used to group related
@@ -213,7 +213,7 @@ important for optimizing system performance and power consumption.
 |===
 
 
-==== Service: *PERF_GET_ATTRIBUTES*
+==== Service: PERF_GET_ATTRIBUTES (SERVICE_ID: 0x03)
 This service is used to retrieve the attributes of a specific performance
 domain. These attributes provide information about the performance capabilities
 and constraints of the domain, such as the performance limit and performance
@@ -271,7 +271,7 @@ pass between two consecutive requests, in microseconds (us).
 | 3:6	| PERF_DOMAIN_NAME | uint8[16]	| Performance domain name, a NULL-terminated ASCII string up to 16-bytes.
 |===
 
-==== Service: *PERF_GET_SUPPORTED_LEVELS*
+==== Service: PERF_GET_SUPPORTED_LEVELS (SERVICE_ID: 0x04)
 This service provides a list of the available performance levels or also called
 operating performance points (OPPs) for a specific performance domain. These
 represent different performance levels that can be set for the components in the
@@ -351,7 +351,7 @@ First index starts from zero.
 |===
 
 
-==== Service: *PERF_GET_LEVEL*
+==== Service: PERF_GET_LEVEL (SERVICE_ID: 0x05)
 This service is used to obtain the current performance level of a specific
 performance domain in the system.
 
@@ -380,7 +380,7 @@ performance domain in the system.
 |===
 
 
-==== Service: *PERF_SET_LEVEL*
+==== Service: PERF_SET_LEVEL (SERVICE_ID: 0x06)
 This service is used to set the current performance level of a specific
 performance domain in the system.
 
@@ -414,7 +414,7 @@ performance level.
 |===
 
 
-==== Service: *PERF_GET_LIMIT*
+==== Service: PERF_GET_LIMIT (SERVICE_ID: 0x07)
 This service is used to obtain the current performance limit of a specific
 performance domain in the system.
 
@@ -444,7 +444,7 @@ performance domain in the system.
 |===
 
 
-==== Service: *PERF_SET_LIMIT*
+==== Service: PERF_SET_LIMIT (SERVICE_ID: 0x08)
 This service is used to set the current performance limit of a specific
 performance domain in the system.
 
@@ -479,7 +479,7 @@ performance level.
 |===
 
 
-==== Service: *PERF_GET_FAST_CHANNEL_ATTRIBUTES*
+==== Service: PERF_GET_FAST_CHANNEL_ATTRIBUTES (SERVICE_ID: 0x09)
 This service allows clients to query attributes of the Fast-channel for a specific performance domain and performance service.
 
 [#table_perf_getfastchanaddr_request_data]

--- a/src/srvgrp-performance.adoc
+++ b/src/srvgrp-performance.adoc
@@ -11,7 +11,7 @@ endif::rootpath[]
 
 ===  Service Group - *PERFORMANCE* (servicegroup_id: 0x00009)
 This PERFORMANCE service group is designed for managing the performance of a
-group of devices or Application Processors that operate in the same performance
+group of devices or application processors that operate in the same performance
 domain. Unlike legacy performance control mechanisms where the OS was responsible
 to directly control the voltage and clocks this mechanism instead operates on
 an metric less integer performance scale. Each integer value on this
@@ -23,9 +23,9 @@ hardware parameters such as voltage and frequency, etc. The mapping between leve
 and frequencies can be as simple as using a multiplication factor of 1000.
 
 The CPPC service group is also intended for performance control but it's only
-for the Application Processors. This service group is primarily intended for
-devices such as GPUs, accelerators, etc but can also be used for Application
-Processors.
+for the application processors. This service group is primarily intended for
+devices such as GPUs, accelerators, etc but can also be used for application
+processors.
 
 It is important to note that performance domains should not be confused with
 power domains. A performance domain is defined as a set of devices that must
@@ -65,7 +65,7 @@ purposes.
 When a client registers for performance change notifications, the platform will
 send notification to the client whenever there is a change in the performance
 level, performance limit or the performance power of a specific performance
-domain. This notification is typically sent by the Platform Microcontroller to
+domain. This notification is typically sent by the platform microcontroller to
 inform clients in the system about changes in the performance domain.
 
 [#table_perf_notification_events]
@@ -152,11 +152,11 @@ The Fast-channel currently supports only the following Performance services:
 
 ==== Service: *PERF_ENABLE_NOTIFICATION*
 This service is to enable or disable the performance changed notification event.
-The notification is sent from the PuC when the performance level, performance
-limit or performance power of a performance domain has changed. This allows the
-system to adjust its behavior in response to performance changes and ensure that
-it is operating within its desired performance level. The supported events are
-described in <<performance-notifications>>.
+The notification is sent from the platform microcontroller when the performance
+level, performance limit or performance power of a performance domain has changed.
+This allows the system to adjust its behavior in response to performance changes
+and ensure that it is operating within its desired performance level. The
+supported events are described in <<performance-notifications>>.
 
 [#table_perf_ennotification_request_data]
 .Request Data
@@ -312,11 +312,11 @@ returned by the PERF_GET_ATTRIBUTES service.
 
 Total words required for the number of performance levels according to the
 format in one message cannot exceed the total words available in one message
-DATA field. If they exceed then PuC will return the number of levels which
-can be accommodated in one message and set the REMAINING field accordingly.
-AP, when REMAINING field is not 0 must call this service again with appropriate
-PERF_LEVEL_INDEX set to get the remaining levels. It's possible that multiple
-service calls may be required to get all the levels.
+DATA field. If they exceed then platform microcontroller will return the number
+of levels which can be accommodated in one message and set the REMAINING field
+accordingly. Application processor, when REMAINING field is not 0 must call this
+service again with appropriate PERF_LEVEL_INDEX set to get the remaining levels.
+It's possible that multiple service calls may be required to get all the levels.
 
 [#table_perf_getdomainlevels_request_data]
 .Request Data

--- a/src/srvgrp-ras-agent.adoc
+++ b/src/srvgrp-ras-agent.adoc
@@ -34,11 +34,12 @@ Below table lists the services in this group:
 This service group does not support any event for notification.
 
 ==== Service: *RAS_ENABLE_NOTIFICATION*
-This service allows the AP to subscribe to RAS_AGENT service group
-notifications. The platform can optionally support notifications of events that
-may occur in the platform. The PuC can send these notification messages to the
-AP if they are implemented and the AP has subscribed to them. The supported
-events are described in <<ras-notifications>>.
+This service allows the application processor to subscribe to RAS_AGENT service
+group notifications. The platform can optionally support notifications of events
+that may occur in the platform. The platform microcontroller can send these
+notification messages to the application processor if they are implemented and
+the application processor has subscribed to them. The supported events are
+described in <<ras-notifications>>.
 
 [#table_ras_ennotification_request_data]
 .Request Data

--- a/src/srvgrp-ras-agent.adoc
+++ b/src/srvgrp-ras-agent.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - *RAS_AGENT* (servicegroup_id: 0x0000B)
+===  Service Group - *RAS_AGENT* (SERVICEGROUP_ID: 0x0000B)
 The RAS agent service group provides services to enumerate various error
 sources in a system and to get their descriptors. These services are provided
 by RAS Agent.
@@ -33,7 +33,7 @@ Below table lists the services in this group:
 ==== Notifications
 This service group does not support any event for notification.
 
-==== Service: *RAS_ENABLE_NOTIFICATION*
+==== Service: RAS_ENABLE_NOTIFICATION (SERVICE_ID: 0x01)
 This service allows the application processor to subscribe to RAS_AGENT service
 group notifications. The platform can optionally support notifications of events
 that may occur in the platform. The platform microcontroller can send these
@@ -66,7 +66,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *RAS_GET_NUM_ERR_SRCS*
+==== Service: RAS_GET_NUM_ERR_SRCS (SERVICE_ID: 0x02)
 This service is used to query number of error sources available in the system.
 
 [#table_ras_agent_getnum_err_srcs_request_data]
@@ -89,7 +89,7 @@ returned as NUM_ERR_SRCS.
 | 1	|	NUM_ERR_SRCS 	| uint32 	| Number of error sources
 |===
 
-==== Service: *RAS_GET_ERR_SRCS_ID_LIST*
+==== Service: RAS_GET_ERR_SRCS_ID_LIST (SERVICE_ID: 0x03)
 This service returns a list of `RAS_ERR_SRC_ID` for all error soruces present
 in the system. The `RAS_ERR_SRC_ID` can be used to get the associated
 descriptor of the error source.
@@ -129,7 +129,7 @@ array is a unique error source ID.
 N is equal to `RETURNED` number of error source IDs in this request +
 |===
 
-==== Service: *RAS_GET_ERR_SRC_DESC*
+==== Service: RAS_GET_ERR_SRC_DESC (SERVICE_ID: 0x04)
 This service returns the error source descriptor of an error source specified
 by `RAS_ERR_SRC_ID`.
 

--- a/src/srvgrp-voltage.adoc
+++ b/src/srvgrp-voltage.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - *VOLTAGE* (servicegroup_id: 0x00006)
+===  Service Group - *VOLTAGE* (SERVICEGROUP_ID: 0x00006)
 The system can be classified into multiple domains for voltage control.
 Each domain is the logical grouping of one or more devices powered by a single
 voltage source. Actions associated with messages within each domain control the
@@ -66,7 +66,7 @@ Below table lists the services in this group:
 ==== Notifications
 This service group does not support any event for notification.
 
-==== Service: *VOLT_ENABLE_NOTIFICATION*
+==== Service: VOLT_ENABLE_NOTIFICATION (SERVICE_ID: 0x01)
 This service allows the application processor to subscribe to VOLTAGE service
 group notifications. The platform can optionally support notifications of events
 which might occur in the platform. The platform microcontroller can send these
@@ -99,7 +99,7 @@ notification.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *VOLT_GET_NUM_DOMAINS*
+==== Service: VOLT_GET_NUM_DOMAINS (SERVICE_ID: 0x02)
 Request for the number of voltage domains available in the system.
 
 [#table_voltage_getnumdomains_request_data]
@@ -122,7 +122,7 @@ as NUM_DOMAINS.
 | 1	|	NUM_DOMAINS 	| uint32 	| Number of voltage domains
 |===
 
-==== Service: *VOLT_GET_ATTRIBUTES*
+==== Service: VOLT_GET_ATTRIBUTES (SERVICE_ID: 0x03)
 Each domain may support multiple voltage levels, which are permitted by the domain
 for operation. For each domain, this message returns a domain name, represented as
 a NULL-terminated ASCII string of 16 bytes. The number of levels indicates the total
@@ -183,7 +183,7 @@ supported by the domain. Get the voltage levels with VOLT_GET_SUPPORTED_LEVELS.
 | 4:7	| VOLTAGE_DOMAIN_NAME	| uint8[16]	| Voltage domain name, a NULL-terminated ASCII string up to 16-bytes.
 |===
 
-==== Service: *VOLT_GET_SUPPORTED_LEVELS*
+==== Service: VOLT_GET_SUPPORTED_LEVELS (SERVICE_ID: 0x04)
 Each domain may support multiple voltage levels which are allowed by the domain
 to operate.
 Depending on the hardware, the voltage levels can be either discrete or stepwise range.
@@ -230,7 +230,7 @@ calls may be necessary to retrieve all the voltage levels.
 | 4	| VOLTAGE_LEVEL[N]	| struct | Voltage level. (<<table_voltage_level>>)
 |===
 
-==== Service: *VOLT_SET_CONFIG*
+==== Service: VOLT_SET_CONFIG (SERVICE_ID: 0x05)
 Set voltage config message enable or disable any voltage domain. Enabling the
 voltage means applying the domain with the voltage level to operate normally.
 The application processor can enable the voltage to any domain without knowing
@@ -275,7 +275,7 @@ specified voltage domain.
 - Other errors <<table_error_codes>>
 |===
 
-==== Service: *VOLT_GET_CONFIG*
+==== Service: VOLT_GET_CONFIG (SERVICE_ID: 0x06)
 Get voltage config message request for the configuration of the voltage domain
 currently set.
 [#table_voltage_getdomainconfig_request_data]
@@ -309,7 +309,7 @@ currently set.
 |===
 
 
-==== Service: *VOLT_SET_LEVEL*
+==== Service: VOLT_SET_LEVEL (SERVICE_ID: 0x07)
 Set the voltage level in microvolts (uV) of a voltage domain.
 
 [#table_voltage_setdomainlevel_request_data]
@@ -339,7 +339,7 @@ voltage domain.
 |===
 
 
-==== Service: *VOLT_GET_LEVEL*
+==== Service: VOLT_GET_LEVEL (SERVICE_ID: 0x08)
 Get the current voltage level in microvolts (uV) of a voltage domain.
 
 [#table_voltage_getdomainlevel_request_data]

--- a/src/srvgrp-voltage.adoc
+++ b/src/srvgrp-voltage.adoc
@@ -67,12 +67,12 @@ Below table lists the services in this group:
 This service group does not support any event for notification.
 
 ==== Service: *VOLT_ENABLE_NOTIFICATION*
-This service allows the AP to subscribe to VOLTAGE service group notifications.
-The platform can optionally support notifications of events which might occur
-in the platform. The PuC can send these notification messages to the AP if
-they are implemented and the AP has subscribed to them. The supported events
-are described in <<voltage-notifications>>.
-
+This service allows the application processor to subscribe to VOLTAGE service
+group notifications. The platform can optionally support notifications of events
+which might occur in the platform. The platform microcontroller can send these
+notification messages to the application processor if they are implemented and
+the application processor has subscribed to them. The supported events are
+described in <<voltage-notifications>>.
 
 [#table_voltage_ennotification_request_data]
 .Request Data
@@ -194,12 +194,12 @@ format of the voltage level.
 
 The total number of words required to represent the voltage levels in one message
 cannot exceed the total words available in one message DATA field. If the number
-of levels exceeds this limit, the PuC will return the maximum number of levels
-that can be accommodated in one message and adjust the REMAINING field accordingly.
-When the REMAINING field is not zero, the AP must make subsequent service calls
-with the appropriate VOLTAGE_LEVEL_INDEX set to retrieve the remaining voltage
-levels. It is possible that multiple service calls may be necessary to retrieve
-all the voltage levels.
+of levels exceeds this limit, the platform microcontroller will return the maximum
+number of levels that can be accommodated in one message and adjust the REMAINING
+field accordingly. When the REMAINING field is not zero, the application processor
+must make subsequent service calls with the appropriate VOLTAGE_LEVEL_INDEX set
+to retrieve the remaining voltage levels. It is possible that multiple service
+calls may be necessary to retrieve all the voltage levels.
 
 [#table_voltage_getdomainlevels_request_data]
 .Request Data
@@ -231,13 +231,15 @@ all the voltage levels.
 |===
 
 ==== Service: *VOLT_SET_CONFIG*
-Set voltage config message enable or disable any voltage domain. Enabling the voltage
-means applying the domain with the voltage level to operate normally. The AP can
-enable the voltage to any domain without knowing the actual voltage levels.
-Disabling the voltage level means disabling the voltage supply to the domain.
+Set voltage config message enable or disable any voltage domain. Enabling the
+voltage means applying the domain with the voltage level to operate normally.
+The application processor can enable the voltage to any domain without knowing
+the actual voltage levels. Disabling the voltage level means disabling the
+voltage supply to the domain.
 
-CONFIG field encodes these discrete settings which do not require AP to know
-the voltage level
+CONFIG field encodes these discrete settings which do not require application
+processor to know the voltage level.
+
 [#table_voltage_setdomainconfig_request_data]
 .Request Data
 [cols="1, 2, 1, 7a", width=100%, align="center", options="header"]


### PR DESCRIPTION
- Standardize the use 'application processor' and 'platform microcontroller'
- Change to use SERVICEGROUP_ID
- Add SERVICE_ID for each service.