### PR TITLE
Expand the error range to allow Implementation specific codes

### DIFF
--- a/src/message-protocol.adoc
+++ b/src/message-protocol.adoc
@@ -350,5 +350,5 @@ specification or the extension version mismatch.
 
 |
 | < -127
-| _Vendor specific_.
+| _Vendor or Implementation specific_.
 |===


### PR DESCRIPTION
Allow vendor specific error code range to also include Implementation specific error codes also.
Vendor and implementation both can define their error codes which will not be exposed in the specification. So allow implementation also to use this range.