### PR TITLE
Add SYSTEM_MSI service group

### DIFF
--- a/riscv-rpmi.adoc
+++ b/riscv-rpmi.adoc
@@ -74,6 +74,8 @@ include::src/service-groups.adoc[]
 
 include::src/srvgrp-base.adoc[]
 
+include::src/srvgrp-system-msi.adoc[]
+
 include::src/srvgrp-system-reset.adoc[]
 
 include::src/srvgrp-system-suspend.adoc[]
@@ -95,8 +97,6 @@ include::src/srvgrp-management.adoc[]
 include::src/srvgrp-ras-agent.adoc[]
 
 include::src/srvgrp-request-forward.adoc[]
-
-include::src/srvgrp-system-msi.adoc[]
 
 include::src/rpmi-mpxy.adoc[]
 

--- a/riscv-rpmi.adoc
+++ b/riscv-rpmi.adoc
@@ -96,6 +96,8 @@ include::src/srvgrp-ras-agent.adoc[]
 
 include::src/srvgrp-request-forward.adoc[]
 
+include::src/srvgrp-system-msi.adoc[]
+
 include::src/rpmi-mpxy.adoc[]
 
 // The index must precede the bibliography

--- a/src/message-protocol.adoc
+++ b/src/message-protocol.adoc
@@ -205,12 +205,11 @@ without supporting or enabling the doorbell interrupt, the behavior is undefined
 
 NOTE: The `FLAGS[3]` bit can be used for a particular RPMI normal request message
 or for the entire life-cycle of RPMI message communication. For example, if the
-application processor and the platform microcontroller supports MSI and
-the application processor has configured MSI target details via a defined service
-<<srvgrp_base_set_msi_target>>, then `FLAGS[3]` bit can always be set to `1` so
-that the platform microcontroller will always send the MSI for every response. The
-application processor can also selectively disable it for a request message so
-that the platform microcontroller does not trigger the doorbell for the response
+P2A doorbell is MSI and the application processor has configured MSI target details
+via `SYSTEM_MSI` service group, then `FLAGS[3]` bit can always be set to `1` so
+that the platform microcontroller will always send the MSI for every response.
+The application processor can also selectively disable it for a request message
+so that the platform microcontroller does not trigger the doorbell for the response
 message.
 
 For an RPMI notification message, the platform microcontroller will set

--- a/src/rpmi-mpxy.adoc
+++ b/src/rpmi-mpxy.adoc
@@ -28,6 +28,9 @@ requirements:
 allowed in S-mode except BASE and CPPC service groups. The <<table_service_groups>>
 list the RPMI service groups allowed in S-mode.
 
+. The SBI MPXY channel corresponding to the RPMI SYSTEM_MSI service group must not
+support the P2A doorbell system MSI.
+
 . The `message_id` parameter passed to the `sbi_mpxy_send_message_with_response()`
 and `sbi_mpxy_send_message_without_response()` must represent the `SERVICE_ID` of
 an RPMI service belonging to the RPMI service group bound to the SBI MPXY channel.

--- a/src/service-groups.adoc
+++ b/src/service-groups.adoc
@@ -117,7 +117,12 @@ RPMI service groups defined by this specification.
 | REQUEST_FORWARD
 | M-mode, S-mode
 
-| 0x000D - 0x7BFF
+| 0x000D
+| 1.0
+| SYSTEM_MSI
+| M-mode, S-mode
+
+| 0x000E - 0x7BFF
 |
 | _Reserved for Future Use_
 |

--- a/src/service-groups.adoc
+++ b/src/service-groups.adoc
@@ -64,62 +64,62 @@ RPMI service groups defined by this specification.
 
 | 0x0002
 | 1.0
-| SYSTEM_RESET
-| M-mode
+| SYSTEM_MSI
+| M-mode, S-mode
 
 | 0x0003
 | 1.0
-| SYSTEM_SUSPEND
+| SYSTEM_RESET
 | M-mode
 
 | 0x0004
 | 1.0
-| HART_STATE_MANAGEMENT
+| SYSTEM_SUSPEND
 | M-mode
 
 | 0x0005
 | 1.0
-| CPPC
-| M-mode, S-mode
+| HART_STATE_MANAGEMENT
+| M-mode
 
 | 0x0006
 | 1.0
-| VOLTAGE
+| CPPC
 | M-mode, S-mode
 
 | 0x0007
 | 1.0
-| CLOCK
+| VOLTAGE
 | M-mode, S-mode
 
 | 0x0008
 | 1.0
-| DEVICE_POWER
+| CLOCK
 | M-mode, S-mode
 
 | 0x0009
 | 1.0
-| PERFORMANCE
+| DEVICE_POWER
 | M-mode, S-mode
 
 | 0x000A
 | 1.0
-| MANAGEMENT_MODE
+| PERFORMANCE
 | M-mode, S-mode
 
 | 0x000B
 | 1.0
-| RAS_AGENT
+| MANAGEMENT_MODE
 | M-mode, S-mode
 
 | 0x000C
 | 1.0
-| REQUEST_FORWARD
+| RAS_AGENT
 | M-mode, S-mode
 
 | 0x000D
 | 1.0
-| SYSTEM_MSI
+| REQUEST_FORWARD
 | M-mode, S-mode
 
 | 0x000E - 0x7BFF

--- a/src/srvgrp-base.adoc
+++ b/src/srvgrp-base.adoc
@@ -58,19 +58,6 @@ The following table lists the services in the BASE service group:
 | 0x07
 | BASE_GET_ATTRIBUTES
 | NORMAL_REQUEST
-
-| 0x08
-| BASE_SET_MSI_STATE
-| NORMAL_REQUEST
-
-| 0x09
-| BASE_GET_MSI_STATE
-| NORMAL_REQUEST
-
-| 0x0A
-| BASE_SET_MSI_TARGET
-| NORMAL_REQUEST
-
 |===
 
 ==== RPMI Implementation IDs
@@ -509,23 +496,17 @@ service group.
 ! Bits
 ! Description
 
-! [31:3]
+! [31:2]
 ! _Reserved_ and must be `0`.
 
-! [2]
+! [1]
 ! RPMI context privilege level.
 
 	0b1: M-mode.
 	0b0: S-mode.
 
-! [1]
-! Event notification support in platform. +
-
-	0b1: Supported.
-	0b0: Not supported.
-
 ! [0]
-! MSI support in platform. +
+! Event notification support in platform. +
 
 	0b1: Supported.
 	0b0: Not supported.
@@ -545,235 +526,4 @@ service group.
 | FLAGS3
 | uint32
 | _Reserved_ and must be `0`.
-|===
-
-[#srvgrp_base_set_msi_state]
-==== Service: BASE_SET_MSI_STATE (SERVICE_ID: 0x08)
-This service is used to control the MSI state such as enable/disable the MSI
-which the platform microcontroller can use as a doorbell to the application
-processor. The application processor can discover the availability of the MSI
-support via the `BASE_GET_ATTRIBUTES` service.
-
-If the MSI support is available, the application processor can enable the
-MSI using this service. If the MSI is not supported, the appropriate error code
-is returned. The platform microcontroller can only send the MSI if it is enabled
-and the MSI target address configured is valid. The target configuration is done
-by another defined service `BASE_SET_MSI_TARGET`.
-
-[#table_base_setmsistate_request_data]
-.Request Data
-[cols="1, 3, 1, 7a", width=100%, align="center", options="header"]
-|===
-| Word
-| Name
-| Type
-| Description
-
-| 0
-| STATE
-| uint32
-| MSI state.
-[cols="2,9a", options="header"]
-!===
-! Bits
-! Description
-
-! [31:1]
-! _Reserved_ and must be `0`.
-
-! [0]
-! MSI enable control.
-
-	0b1: Enable MSI.
-	0b0: Disable MSI.
-
-!===
-|===
-
-[#table_base_setmsistate_response_data]
-.Response Data
-[cols="1, 1, 1, 7a", width=100%, align="center", options="header"]
-|===
-| Word
-| Name
-| Type
-| Description
-
-| 0
-| STATUS
-| int32
-| Return error code.
-
-[cols="7,5a", options="header"]
-!===
-! Error Code
-! Description
-
-! RPMI_SUCCESS
-! MSI is enabled or disabled successfully.
-
-! RPMI_ERR_NOT_SUPPORTED
-! MSI is not supported.
-
-! RPMI_ERR_INVALID_PARAM
-! `STATE` value is reserved or invalid.
-
-!===
-- Other errors <<table_error_codes>>.
-|===
-
-[#srvgrp_base_get_msi_state]
-==== Service: BASE_GET_MSI_STATE (SERVICE_ID: 0x09)
-This service is used to get the state of the MSI, whether the MSI is
-enabled/disabled or if the MSI is currently pending and the platform microcontroller
-is unable to send.
-
-NOTE: The MSI can be pending for a number of reasons, for example, if the MSI
-target address and data are not configured, or if the configured MSI target address
-is not valid. The application processor should configure a valid MSI target using
-the `BASE_SET_MSI_TARGET` service.
-
-If the MSI is not supported by the platform microcontroller, the appropriate
-error code will be returned.
-
-NOTE: Not all bits defined in the `STATE` field have a corresponding bit in the 
-`BASE_SET_MSI_STATE` service. There may be additional state bits which are defined
-which are read-only and cannot be controlled by the application processor.
-
-[#table_base_getmsistate_request_data]
-.Request Data
-[cols="1", width=100%, align="center", options="header"]
-|===
-| NA
-|===
-
-[#table_base_getmsistate_response_data]
-.Response Data
-[cols="1, 1, 1, 7a", width=100%, align="center", options="header"]
-|===
-| Word
-| Name
-| Type
-| Description
-
-| 0
-| STATUS
-| int32
-| Return error code.
-
-[cols="7,5a", options="header"]
-!===
-! Error Code
-! Description
-
-! RPMI_SUCCESS
-! MSI state is returned successfully.
-
-! RPMI_ERR_NOT_SUPPORTED
-! MSI is not supported.
-!===
-- Other errors <<table_error_codes>>.
-
-| 1
-| STATE
-| uint32
-| MSI state.
-[cols="2,9a", options="header"]
-!===
-! Bits
-! Description
-
-! [31:2]
-! _Reserved_ and must be `0`.
-
-! [1]
-! MSI pending state. +
-
-	0b1: MSI is pending.
-	0b0: MSI is not pending.
-
-! [0]
-! MSI enable state.
-
-	0b1: MSI enabled.
-	0b0: MSI disabled.
-!===
-|===
-
-
-[#srvgrp_base_set_msi_target]
-==== Service: BASE_SET_MSI_TARGET (SERVICE_ID: 0x0A)
-This service is used to configure the MSI target address and data which the
-platform microcontroller can use as a doorbell to the application processor. The
-application processor may first discover the MSI support via the
-`BASE_GET_ATTRIBUTES` service. 
-
-The platform microcontroller can only send the MSI if it is enabled and the
-configured MSI target address is valid. The platform must validate the MSI target
-address before sending the MSI.
-
-If MSI is not supported or not enabled, this service will be ignored and an
-appropriate error will be returned. If the MSI target address is invalid then
-an appropriate error code will be returned.
-
-NOTE: The platform microcontroller can use MSI for sending the MSI
-directly or injecting wired interrupt in the application processor. If the MSI
-target address is IMSIC, then the application processor will take MSI whereas
-if the MSI target address is `setipnum` of the APLIC then the application
-processor will take the wired interrupt.
-
-[#table_base_setmsitarget_request_data]
-.Request Data
-[cols="1, 3, 1, 7", width=100%, align="center", options="header"]
-|===
-| Word
-| Name
-| Type
-| Description
-
-| 0
-| MSI_ADDRESS_LOW
-| uint32
-| Lower 32-bit of the MSI address.
-
-| 1
-| MSI_ADDRESS_HIGH
-| uint32
-| Upper 32-bit of the MSI address.
-
-| 2
-| MSI_DATA
-| uint32
-| 32-bit MSI data.
-|===
-
-[#table_base_setmsitarget_response_data]
-.Response Data
-[cols="1, 1, 1, 7a", width=100%, align="center", options="header"]
-|===
-| Word
-| Name
-| Type
-| Description
-
-| 0
-| STATUS
-| int32
-| Return error code.
-
-[cols="7,5a", options="header"]
-!===
-! Error Code
-! Description
-
-! RPMI_SUCCESS
-! MSI address and data are configured successfully.
-
-! RPMI_ERR_NOT_SUPPORTED
-! MSI is not supported.
-
-! RPMI_ERR_INVALID_ADDR
-! MSI target address is invalid or it is not `4-byte` aligned.
-!===
-- Other errors <<table_error_codes>>.
 |===

--- a/src/srvgrp-clock.adoc
+++ b/src/srvgrp-clock.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - CLOCK (SERVICEGROUP_ID: 0x0007)
+===  Service Group - CLOCK (SERVICEGROUP_ID: 0x0008)
 This service group is for the management of system clocks. Services defined in
 this group are used to enable or disable clocks, and to set or get clock rates.
 

--- a/src/srvgrp-cppc.adoc
+++ b/src/srvgrp-cppc.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-=== Service Group - CPPC (SERVICEGROUP_ID: 0x0005)
+=== Service Group - CPPC (SERVICEGROUP_ID: 0x0006)
 This service group defines the services to control application processor
 performance by managing a set of registers per application processor
 that are used for performance management and control. The ACPI CPPC

--- a/src/srvgrp-device-power.adoc
+++ b/src/srvgrp-device-power.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - DEVICE_POWER (SERVICEGROUP_ID: 0x0008)
+===  Service Group - DEVICE_POWER (SERVICEGROUP_ID: 0x0009)
 This DEVICE_POWER service group provides messages to manage the power states of
 a device power domain. This service group is used only for device power
 management since system and CPU power management is handled by already defined

--- a/src/srvgrp-hart-state-management.adoc
+++ b/src/srvgrp-hart-state-management.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-=== Service Group - HART_STATE_MANAGEMENT (SERVICEGROUP_ID: 0x0004)
+=== Service Group - HART_STATE_MANAGEMENT (SERVICEGROUP_ID: 0x0005)
 This service group defines services to control and manage the application
 processor (hart) power states. Hart power states include power on, power off,
 suspend modes, etc. A hart is identified by a 32-bit identifier called `HART_ID`.

--- a/src/srvgrp-management.adoc
+++ b/src/srvgrp-management.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - MANAGEMENT_MODE (SERVICEGROUP_ID: 0x000A)
+===  Service Group - MANAGEMENT_MODE (SERVICEGROUP_ID: 0x000B)
 This MANAGEMENT_MODE service group provides RPMI client a mechanism to invoke the
 Management Mode (MM) in a secure execution environment. For general background on
 Management Mode, refer to the Platform Initialization (PI) specifications cite:[PI],

--- a/src/srvgrp-performance.adoc
+++ b/src/srvgrp-performance.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - PERFORMANCE (SERVICEGROUP_ID: 0x0009)
+===  Service Group - PERFORMANCE (SERVICEGROUP_ID: 0x000A)
 This PERFORMANCE service group is used to manage the performance of a
 group of devices or application processors that operate in the same performance
 domain. Unlike traditional performance control mechanisms, where the OS is

--- a/src/srvgrp-ras-agent.adoc
+++ b/src/srvgrp-ras-agent.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - RAS_AGENT (SERVICEGROUP_ID: 0x000B)
+===  Service Group - RAS_AGENT (SERVICEGROUP_ID: 0x000C)
 The RAS_AGENT service group provides services to enumerate various error
 sources in a system and to retrieve their descriptors.
 

--- a/src/srvgrp-request-forward.adoc
+++ b/src/srvgrp-request-forward.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - REQUEST_FORWARD (SERVICEGROUP_ID: 0x000C)
+===  Service Group - REQUEST_FORWARD (SERVICEGROUP_ID: 0x000D)
 The REQUEST_FORWARD service group allows application processors to retrieve and
 process RPMI request messages which are forwarded by platform microcontroller from
 some other RPMI client. This service group also allows an SBI implementation to

--- a/src/srvgrp-system-msi.adoc
+++ b/src/srvgrp-system-msi.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - SYSTEM_MSI (SERVICEGROUP_ID: 0x000D)
+===  Service Group - SYSTEM_MSI (SERVICEGROUP_ID: 0x0002)
 The SYSTEM_MSI service group defines services to allow application processors
 to receive MSIs upon system events such as P2A doorbell, graceful shutdown/reboot
 request, CPU hotplug event, memory hotplug event, etc.

--- a/src/srvgrp-system-msi.adoc
+++ b/src/srvgrp-system-msi.adoc
@@ -1,0 +1,565 @@
+:path: src/
+:imagesdir: ../images
+
+ifdef::rootpath[]
+:imagesdir: {rootpath}{path}{imagesdir}
+endif::rootpath[]
+
+ifndef::rootpath[]
+:rootpath: ./../
+endif::rootpath[]
+
+===  Service Group - SYSTEM_MSI (SERVICEGROUP_ID: 0x000D)
+The SYSTEM_MSI service group defines services to allow application processors
+to receive MSIs upon system events such as P2A doorbell, graceful shutdown/reboot
+request, CPU hotplug event, memory hotplug event, etc.
+
+The number of system MSIs supported by this service group is fixed and referred
+to as `SYS_NUM_MSI`. Each system MSI is associated with a unique index which is
+also referred to as `SYS_MSI_INDEX` where `0 <= SYS_MSI_INDEX < SYS_NUM_MSI`.
+
+The association between system events and system MSI index (aka `SYS_MSI_INDEX`)
+is platform specific and must be discovered using hardware description mechanisms
+such as device tree or ACPI. The `SYS_NUM_MSI` value and `SYS_MSI_INDEX` of the
+P2A doorbell system MSI can be discovered using the `SYSMSI_GET_ATTRIBUTES` service.
+
+The system MSI state is 32-bit word also referred to as `SYS_MSI_STATE` which
+includes whether the system MSI is enabled/disabled and whether system MSI is
+currently pending at the platform microcontroller. The <<table_sysmsi_state>>
+below shows the encoding of `SYS_MSI_STATE`.
+
+NOTE: A system MSI can be pending for several reasons. For example, if the MSI
+target address and data are not configured, or if the configured MSI target
+address is not valid.
+
+[#table_sysmsi_state]
+.System MSI State
+[cols="2,2,7a", width=60%, align="center", options="header"]
+|===
+| Bits
+| Permission
+| Description
+
+| [31:2]
+| NA
+| _Reserved_ and must be `0`.
+
+| [1]
+| Read-Only
+| MSI pending state. +
+  0b1: MSI is pending. +
+  0b0: MSI is not pending.
+
+| [0]
+| Read-Write
+| MSI enable state. +
+  0b1: MSI enabled. +
+  0b0: MSI disabled.
+|===
+
+The platform microcontroller can only send a pending system MSI if it is
+enabled and the configured with a valid MSI target address. The system MSI
+can be enabled/disabled using the `SYSMSI_SET_MSI_STATE` service whereas the
+system MSI target configuration can be done using the `SYSMSI_SET_MSI_TARGET`
+service.
+
+NOTE: If the system MSI target address is IMSIC, then the application
+processors will directly receive the system MSI whereas if the system
+MSI target address is `setipnum` register of a APLIC domain then the
+application processors receive it as wired interrupt.
+
+The <<table_sysmsi_services>> below lists the services in the SYSTEM_MSI
+service group:
+
+[#table_sysmsi_services]
+.SYSTEM_MSI Services
+[cols="1, 3, 2", width=100%, align="center", options="header"]
+|===
+| Service ID
+| Service Name
+| Request Type
+
+| 0x01
+| SYSMSI_ENABLE_NOTIFICATION
+| NORMAL_REQUEST
+
+| 0x02
+| SYSMSI_GET_ATTRIBUTES
+| NORMAL_REQUEST
+
+| 0x03
+| SYSMSI_GET_MSI_ATTRIBUTES
+| NORMAL_REQUEST
+
+| 0x04
+| SYSMSI_SET_MSI_STATE
+| NORMAL_REQUEST
+
+| 0x05
+| SYSMSI_GET_MSI_STATE
+| NORMAL_REQUEST
+
+| 0x06
+| SYSMSI_SET_MSI_TARGET
+| NORMAL_REQUEST
+
+| 0x07
+| SYSMSI_GET_MSI_TARGET
+| NORMAL_REQUEST
+|===
+
+[#system-msi-notifications]
+==== Notifications
+This service group does not support any events for notification.
+
+==== Service: SYSMSI_ENABLE_NOTIFICATION (SERVICE_ID: 0x01)
+This service allows the application processor to subscribe to `SYSTEM_MSI`
+service group notifications. The platform may optionally support notifications
+for events that may occur. The platform microcontroller can send these
+notification messages to the application processor if they are implemented and
+the application processor has subscribed to them. The supported events are
+described in <<system-msi-notifications>>.
+
+[#table_sysmsi_ennotification_request_data]
+.Request Data
+[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| EVENT_ID
+| uint32
+| The event to be subscribed for notification.
+
+| 1
+| REQ_STATE
+| uint32
+| Requested event notification state. +
+Change or query the current state of `EVENT_ID` notification.
+----
+0: Disable.
+1: Enable.
+2: Return current state.
+----
+Any other values of `REQ_STATE` field other than the defined ones are reserved
+for future use.
+|===
+
+[#table_sysmsi_ennotification_response_data]
+.Response Data
+[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| STATUS
+| int32
+| Return error code.
+
+[cols="6,5a", options="header"]
+!===
+! Error Code
+! Description
+
+! RPMI_SUCCESS
+! Event is subscribed successfully.
+
+! RPMI_ERR_INVALID_PARAM
+! `EVENT_ID` or `REQ_STATE` is invalid.
+
+! RPMI_ERR_NOT_SUPPORTED
+! Notification is not supported.
+!===
+- Other errors <<table_error_codes>>.
+
+| 1
+| CURRENT_STATE
+| uint32
+| Current `EVENT_ID` notification state.
+----
+0: Notification is disabled.
+1: Notification is enabled.
+----
+In case of `REQ_STATE = 0` or `1`, the `CURRENT_STATE` will return the requested
+state. +
+In case of an error, the value of `CURRENT_STATE` is unspecified.
+|===
+
+
+==== Service: SYSMSI_GET_ATTRIBUTES (SERVICE_ID: 0x02)
+This service is used to discover attributes of the system MSI service group.
+
+[#table_sysmsi_getattrs_request_data]
+.Request Data
+[cols="1", width=100%, align="center", options="header"]
+|===
+| NA
+|===
+
+[#table_sysmsi_getattrs_response_data]
+.Response Data
+[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| STATUS
+| int32
+| Return error code.
+
+[cols="5,5", options="header"]
+!===
+! Error Code
+! Description
+
+! RPMI_SUCCESS
+! Service completed successfully.
+
+!===
+- Other errors <<table_error_codes>>.
+
+| 1
+| SYS_NUM_MSI
+| uint32
+| Number of system MSIs.
+
+| 2
+| P2A_DB_INDEX
+| uint32
+| System MSI index or `SYS_MSI_INDEX` of the P2A doorbell. If P2A doorbell
+  is not supported as system MSI then `0xffffffff` value should be returned.
+
+| 3
+| FLAGS0
+| uint32
+| _Reserved_ and must be `0`.
+
+| 4
+| FLAGS1
+| uint32
+| _Reserved_ and must be `0`.
+|===
+
+
+==== Service: SYSMSI_GET_MSI_ATTRIBUTES (SERVICE_ID: 0x03)
+This service is used to discover attributes of a particular system MSI.
+
+[#table_sysmsi_getmsiattrs_request_data]
+.Request Data
+[cols="1, 2, 1, 7", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| SYS_MSI_INDEX
+| uint32
+| Index of the system MSI.
+|===
+
+[#table_sysmsi_getmsiattrs_response_data]
+.Response Data
+[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| STATUS
+| int32
+| Return error code.
+
+[cols="5,5", options="header"]
+!===
+! Error Code
+! Description
+
+! RPMI_SUCCESS
+! Service completed successfully.
+
+! RPMI_ERR_INVALID_PARAM
+! `SYS_MSI_INDEX` value is greater than `SYS_NUM_MSI`.
+!===
+- Other errors <<table_error_codes>>.
+
+| 1
+| SYS_MSI_NAME
+| uint8[16]
+| System MSI name, a NULL-terminated ASCII string up to 16-bytes.
+
+| 2
+| FLAGS0
+| uint32
+|
+[cols="2,9a", options="header"]
+!===
+! Bits
+! Description
+
+! [31:1]
+! _Reserved_ and must be `0`.
+
+! [0]
+! Preferred privilege level for MSI handling. +
+
+	0b1: M-mode.
+	0b0: M-mode or S-mode.
+!===
+
+| 3
+| FLAGS1
+| uint32
+| _Reserved_ and must be `0`.
+|===
+
+
+[#srvgrp_sysmsi_set_msi_state]
+==== Service: SYSMSI_SET_MSI_STATE (SERVICE_ID: 0x04)
+This service is used to update the state of a system MSI. Specifically,
+it allows application processors to enable or disable a system MSI. The
+read-only bits of the system MSI state are not updated by this service.
+
+[#table_sysmsi_setmsistate_request_data]
+.Request Data
+[cols="1, 2, 1, 7", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| SYS_MSI_INDEX
+| uint32
+| Index of the system MSI.
+
+| 1
+| SYS_MSI_STATE
+| uint32
+| System MSI state as defined in <<table_sysmsi_state>>.
+|===
+
+[#table_sysmsi_setmsistate_response_data]
+.Response Data
+[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| STATUS
+| int32
+| Return error code.
+
+[cols="5,5a", options="header"]
+!===
+! Error Code
+! Description
+
+! RPMI_SUCCESS
+! MSI is enabled or disabled successfully.
+
+! RPMI_ERR_INVALID_PARAM
+! `SYS_MSI_INDEX` value is greater than `SYS_NUM_MSI` or
+ `SYS_MSI_STATE` value is reserved or invalid.
+
+!===
+- Other errors <<table_error_codes>>.
+|===
+
+
+[#srvgrp_sysmsi_get_msi_state]
+==== Service: SYSMSI_GET_MSI_STATE (SERVICE_ID: 0x05)
+This service is used to get the current state of a system MSI.
+
+[#table_sysmsi_getmsistate_request_data]
+.Request Data
+[cols="1, 2, 1, 7", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| SYS_MSI_INDEX
+| uint32
+| Index of the system MSI.
+|===
+
+[#table_sysmsi_getmsistate_response_data]
+.Response Data
+[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| STATUS
+| int32
+| Return error code.
+
+[cols="5,5a", options="header"]
+!===
+! Error Code
+! Description
+
+! RPMI_SUCCESS
+! MSI state is returned successfully.
+
+! RPMI_ERR_INVALID_PARAM
+! `SYS_MSI_INDEX` value is greater than `SYS_NUM_MSI`.
+!===
+- Other errors <<table_error_codes>>.
+
+| 1
+| SYS_MSI_STATE
+| uint32
+| System MSI state as defined in <<table_sysmsi_state>>.
+|===
+
+
+[#srvgrp_sysmsi_set_msi_target]
+==== Service: SYSMSI_SET_MSI_TARGET (SERVICE_ID: 0x06)
+This service is used to configure the target address and data of a system MSI.
+
+[#table_sysmsi_setmsitarget_request_data]
+.Request Data
+[cols="1, 4, 1, 7", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| SYS_MSI_INDEX
+| uint32
+| Index of the system MSI.
+
+| 1
+| SYS_MSI_ADDRESS_LOW
+| uint32
+| Lower 32-bit of the MSI address.
+
+| 2
+| SYS_MSI_ADDRESS_HIGH
+| uint32
+| Upper 32-bit of the MSI address.
+
+| 3
+| SYS_MSI_DATA
+| uint32
+| 32-bit MSI data.
+|===
+
+[#table_sysmsi_setmsitarget_response_data]
+.Response Data
+[cols="1, 4, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| STATUS
+| int32
+| Return error code.
+
+[cols="5,5a", options="header"]
+!===
+! Error Code
+! Description
+
+! RPMI_SUCCESS
+! MSI address and data are configured successfully.
+
+! RPMI_ERR_INVALID_PARAM
+! `SYS_MSI_INDEX` value is greater than `SYS_NUM_MSI`.
+
+! RPMI_ERR_INVALID_ADDR
+! MSI target address is invalid or it is not `4-byte` aligned.
+!===
+- Other errors <<table_error_codes>>.
+|===
+
+
+[#srvgrp_sysmsi_get_msi_target]
+==== Service: SYSMSI_GET_MSI_TARGET (SERVICE_ID: 0x07)
+This service is used to get the current target address and data of a system MSI.
+
+[#table_sysmsi_getmsitarget_request_data]
+.Request Data
+[cols="1, 4, 1, 7", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| SYS_MSI_INDEX
+| uint32
+| Index of the system MSI.
+|===
+
+[#table_sysmsi_getmsitarget_response_data]
+.Response Data
+[cols="1, 4, 1, 7a", width=100%, align="center", options="header"]
+|===
+| Word
+| Name
+| Type
+| Description
+
+| 0
+| STATUS
+| int32
+| Return error code.
+
+[cols="5,5a", options="header"]
+!===
+! Error Code
+! Description
+
+! RPMI_SUCCESS
+! MSI target details returned successfully.
+
+! RPMI_ERR_INVALID_PARAM
+! `SYS_MSI_INDEX` value is greater than `SYS_NUM_MSI`.
+!===
+- Other errors <<table_error_codes>>.
+
+| 1
+| SYS_MSI_ADDRESS_LOW
+| uint32
+| Lower 32-bit of the MSI address.
+
+| 2
+| SYS_MSI_ADDRESS_HIGH
+| uint32
+| Upper 32-bit of the MSI address.
+
+| 3
+| SYS_MSI_DATA
+| uint32
+| 32-bit MSI data.
+|===

--- a/src/srvgrp-system-reset.adoc
+++ b/src/srvgrp-system-reset.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - SYSTEM_RESET (SERVICEGROUP_ID: 0x0002)
+===  Service Group - SYSTEM_RESET (SERVICEGROUP_ID: 0x0003)
 This service group defines services for system-level reset or shutdown.
 
 The architectural reset types that are supported by default are System Cold

--- a/src/srvgrp-system-suspend.adoc
+++ b/src/srvgrp-system-suspend.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - SYSTEM_SUSPEND (SERVICEGROUP_ID: 0x0003)
+===  Service Group - SYSTEM_SUSPEND (SERVICEGROUP_ID: 0x0004)
 This service group defines services used to request platform microcontroller
 to transition the system into a suspend state, also called a sleep state.
 The suspend state `SUSPEND_TO_RAM` is supported by default by the platform and

--- a/src/srvgrp-voltage.adoc
+++ b/src/srvgrp-voltage.adoc
@@ -9,7 +9,7 @@ ifndef::rootpath[]
 :rootpath: ./../
 endif::rootpath[]
 
-===  Service Group - VOLTAGE (SERVICEGROUP_ID: 0x0006)
+===  Service Group - VOLTAGE (SERVICEGROUP_ID: 0x0007)
 The system can be classified into multiple domains for voltage control. Each
 domain is the logical grouping of one or more devices powered by a single
 voltage source. Actions associated with messages within each domain control the

--- a/src/transport.adoc
+++ b/src/transport.adoc
@@ -74,8 +74,8 @@ processors must discover it using standard hardware description mechanisms
 such as device tree or ACPI.
 
 If the P2A doorbell is a MSI then the application processors must configure
-the MSI on the platform microcontroller side using the RPMI service defined by
-the `BASE` service group.
+the P2A doorbell MSI on the platform microcontroller side using RPMI services
+defined by the `SYSTEM_MSI` service group.
 
 NOTE: If the platform supports PLIC, the platform need to provide a MMIO
 register to inject an edge-triggered interrupt.


### PR DESCRIPTION
This PR factors-out MSI support in BASE service group to a more generic SYSTEM_MSI service group which manages system MSIs from platform microcontroller.