### PR TITLE
rpmi: sysreset: Remove the redundant response for the SYSRST_RESET

### DIFF
--- a/src/srvgrp-system-reset.adoc
+++ b/src/srvgrp-system-reset.adoc
@@ -211,8 +211,9 @@ Refer <<section-reset-types>> for more details.
 This service is used to initiate the system reset or system shutdown.
 The application processor must only request supported reset types, discovered
 using the `SYSRST_GET_ATTRIBUTES` service except for System Shutdown and System
-Cold Reset which are supported by default. This service does not return response
-message in case of successful reset.
+Cold Reset which are supported by default. This service does not return a response.
+If an unsupported reset type is provided, or if the system reset fails, the
+resulting system state is unspecified.
 
 [#table_sysreset_sysreset_request_data]
 .Request Data
@@ -233,25 +234,7 @@ Refer <<section-reset-types>> for more details.
 
 [#table_sysreset_sysreset_response_data]
 .Response Data
-[cols="1, 2, 1, 7a", width=100%, align="center", options="header"]
+[cols="1", width=100%, align="center", options="header"]
 |===
-| Word
-| Name
-| Type
-| Description
-
-| 0
-| STATUS
-| int32
-| Return error code.
-
-[cols="5,5a", options="header"]
-!===
-! Error Code
-! Description
-
-! RPMI_ERR_INVALID_PARAM
-! Reset type is not supported or invalid.
-!===
-- Other errors <<table_error_codes>>.
+| NA
 |===


### PR DESCRIPTION
SYSRST_RESET service in System Reset service group is Posted Request and does not have a response. This service is responsible for performing the system reset and its not expected to return. Remove the redundant response details for this service.

This change does not change the functionality and the current implementation in OpenSBI also remains unchanged since it does not expects a response after issuing this service for system reset.