### PR TITLE
Add RPMI Version for each service in each service group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@
 # the Doc Template for RISC-V Extensions.
 
 DATE ?= $(shell date +%Y-%m-%d)
-VERSION ?= v1.0
-REVMARK ?= Ratified
+VERSION ?= v2.0
+REVMARK ?= Draft
 DOCKER_RUN := docker run --rm -v ${PWD}:/build -w /build \
 ghcr.io/riscv/riscv-docs-base-container-image:latest
 

--- a/riscv-rpmi.adoc
+++ b/riscv-rpmi.adoc
@@ -4,8 +4,8 @@
 :description: RISC-V Platform Management Interface Specification Document (RPMI)
 :company: RISC-V.org
 :revdate: 1/2023
-:revnumber: 1.0
-:revremark: Ratified
+:revnumber: 2.0
+:revremark: Draft
 :revinfo:
 :url-riscv: http://riscv.org
 :doctype: book
@@ -39,10 +39,11 @@ endif::[]
 :xrefstyle: short
 
 [WARNING]
-.This document is in the link:http://riscv.org/spec-state[Ratified state]
+.This document is in the link:http://riscv.org/spec-state[Draft state]
 ====
-No changes are allowed. Any necessary or desired modifications must be addressed
-through a follow-on extension. Ratified extensions are never revised.
+Assume everything is subject to change. At this stage, ideas, structures,
+and content are still evolving. Feedback and iteration are encouraged as nothing
+is final, and adjustments may be frequent.
 ====
 
 [preface]

--- a/src/contributors.adoc
+++ b/src/contributors.adoc
@@ -4,11 +4,6 @@ This RISC-V specification has been contributed to directly or indirectly by:
 
 [%hardbreaks]
 
-Anup Patel <apatel@ventanamicro.com>
-Himanshu Chauhan <hchauhan@ventanamicro.com>
-Joshua Yeong <joshua.yeong@starfivetech.com>
-Ley Foon Tan <leyfoon.tan@starfivetech.com>
-Rahul Pathak <rpathak@ventanamicro.com>
-Samuel Holland <samuel.holland@sifive.com>
-Subrahmanya Lingappa <slingappa@ventanamicro.com>
-Yong Li <yong.li@intel.com>
+
+Anup Patel, Christian Bolis, Himanshu Chauhan, Joshua Yeong, Ley Foon Tan, Rahul Pathak, Samuel Holland, Subrahmanya Lingappa, Yong Li
+

--- a/src/srvgrp-base.adoc
+++ b/src/srvgrp-base.adoc
@@ -25,39 +25,47 @@ The following table lists the services in the BASE service group:
 
 [#table_base_services]
 .BASE Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | BASE_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | BASE_GET_IMPLEMENTATION_VERSION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | BASE_GET_IMPLEMENTATION_ID
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | BASE_GET_SPEC_VERSION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x05
 | BASE_GET_PLATFORM_INFO
 | NORMAL_REQUEST
+| 1.0
 
 | 0x06
 | BASE_PROBE_SERVICE_GROUP
 | NORMAL_REQUEST
+| 1.0
 
 | 0x07
 | BASE_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 |===
 
 ==== RPMI Implementation IDs

--- a/src/srvgrp-clock.adoc
+++ b/src/srvgrp-clock.adoc
@@ -30,43 +30,52 @@ The following table lists the services in the CLOCK service group:
 
 [#table_clock_services]
 .CLOCK Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | CLK_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | CLK_GET_NUM_CLOCKS
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | CLK_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | CLK_GET_SUPPORTED_RATES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x05
 | CLK_SET_CONFIG
 | NORMAL_REQUEST
+| 1.0
 
 | 0x06
 | CLK_GET_CONFIG
 | NORMAL_REQUEST
+| 1.0
 
 | 0x07
 | CLK_SET_RATE
 | NORMAL_REQUEST
+| 1.0
 
 | 0x08
 | CLK_GET_RATE
 | NORMAL_REQUEST
+| 1.0
 |===
 
 [#clock-rate-format-section]

--- a/src/srvgrp-cppc.adoc
+++ b/src/srvgrp-cppc.adoc
@@ -40,39 +40,47 @@ The following table lists the services in the CPPC service group:
 
 [#table_cppc_services]
 .CPPC Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | CPPC_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | CPPC_PROBE_REG
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | CPPC_READ_REG
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | CPPC_WRITE_REG
 | NORMAL_REQUEST
+| 1.0
 
 | 0x05
 | CPPC_GET_FAST_CHANNEL_REGION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x06
 | CPPC_GET_FAST_CHANNEL_OFFSET
 | NORMAL_REQUEST
+| 1.0
 
 | 0x07
 | CPPC_GET_HART_LIST
 | NORMAL_REQUEST
+| 1.0
 |===
 
 ==== CPPC Fast-channel

--- a/src/srvgrp-device-power.adoc
+++ b/src/srvgrp-device-power.adoc
@@ -35,31 +35,37 @@ The following table lists the services in the DEVICE_POWER service group:
 
 [#table_devpower_services]
 .DEVICE_POWER Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | DPWR_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | DPWR_GET_NUM_DOMAINS
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | DPWR_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | DPWR_SET_STATE
 | NORMAL_REQUEST
+| 1.0
 
 | 0x05
 | DPWR_GET_STATE
 | NORMAL_REQUEST
+| 1.0
 |===
 
 [#section-power-state]

--- a/src/srvgrp-hart-state-management.adoc
+++ b/src/srvgrp-hart-state-management.adoc
@@ -25,44 +25,52 @@ The following table lists the services in the HART_STATE_MANAGEMENT service grou
 
 [#table_hsm_services]
 .HART_STATE_MANAGEMENT Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | HSM_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | HSM_GET_HART_STATUS
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | HSM_GET_HART_LIST
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | HSM_GET_SUSPEND_TYPES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x05
 | HSM_GET_SUSPEND_INFO
 | NORMAL_REQUEST
+| 1.0
 
 | 0x06
 | HSM_HART_START
 | NORMAL_REQUEST
+| 1.0
 
 | 0x07
 | HSM_HART_STOP
 | NORMAL_REQUEST
+| 1.0
 
 | 0x08
 | HSM_HART_SUSPEND
 | NORMAL_REQUEST
-
+| 1.0
 |===
 
 [#section-hart-states]

--- a/src/srvgrp-logging.adoc
+++ b/src/srvgrp-logging.adoc
@@ -16,19 +16,22 @@ The following table lists the services in the LOGGING service group:
 
 [#table_logging_services]
 .LOGGING Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | LOG_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 2.0
 
 | 0x02
 | LOG_DATA
 | NORMAL_REQUEST
+| 2.0
 
 |===
 

--- a/src/srvgrp-management.adoc
+++ b/src/srvgrp-management.adoc
@@ -26,23 +26,27 @@ The following table lists the services in the MANAGEMENT_MODE service group:
 
 [#table_mm_services]
 .MANAGEMENT_MODE Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | MM_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | MM_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | MM_COMMUNICATE
 | NORMAL_REQUEST
+| 1.0
 |===
 
 [#management-notifications]

--- a/src/srvgrp-performance.adoc
+++ b/src/srvgrp-performance.adoc
@@ -39,52 +39,62 @@ The following table lists the services in the PERFORMANCE service group:
 
 [#table_perf_services]
 .PERFORMANCE Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | PERF_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | PERF_GET_NUM_DOMAINS
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | PERF_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | PERF_GET_SUPPORTED_LEVELS
 | NORMAL_REQUEST
+| 1.0
 
 | 0x05
 | PERF_GET_LEVEL
 | NORMAL_REQUEST
+| 1.0
 
 | 0x06
 | PERF_SET_LEVEL
 | NORMAL_REQUEST
+| 1.0
 
 | 0x07
 | PERF_GET_LIMIT
 | NORMAL_REQUEST
+| 1.0
 
 | 0x08
 | PERF_SET_LIMIT
 | NORMAL_REQUEST
+| 1.0
 
 | 0x09
 | PERF_GET_FAST_CHANNEL_REGION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x0A
 | PERF_GET_FAST_CHANNEL_ATTRIBUTES
 | NORMAL_REQUEST
-
+| 1.0
 |===
 
 [#section-perf-level-attribute]

--- a/src/srvgrp-ras-agent.adoc
+++ b/src/srvgrp-ras-agent.adoc
@@ -20,27 +20,32 @@ The following table lists the services in the RAS_AGENT service group:
 
 [#table_ras_agent_services]
 .RAS Agent Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | RAS_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | RAS_GET_NUM_ERR_SRCS
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | RAS_GET_ERR_SRCS_ID_LIST
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | RAS_GET_ERR_SRC_DESC
 | NORMAL_REQUEST
+| 1.0
 |===
 
 ==== Error Source Descriptor Format

--- a/src/srvgrp-request-forward.adoc
+++ b/src/srvgrp-request-forward.adoc
@@ -27,23 +27,27 @@ service group:
 
 [#table_reqfwd_services]
 .Request Forward Services
-[cols="1, 4, 2", width=100%, align="center", options="header"]
+[cols="1, 4, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | REQFWD_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | REQFWD_RETRIEVE_CURRENT_MESSAGE
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | REQFWD_COMPLETE_CURRENT_MESSAGE
 | NORMAL_REQUEST
+| 1.0
 |===
 
 [#reqfwd-notifications]

--- a/src/srvgrp-system-irq.adoc
+++ b/src/srvgrp-system-irq.adoc
@@ -92,47 +92,57 @@ service group:
 
 [#table_sysirq_services]
 .SYSTEM_IRQ Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | SYSIRQ_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 2.0
 
 | 0x02
 | SYSIRQ_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 2.0
 
 | 0x03
 | SYSIRQ_GET_TARGET_ATTRIBUTES
 | NORMAL_REQUEST
+| 2.0
 
 | 0x04
 | SYSIRQ_GET_IRQ_ATTRIBUTES
 | NORMAL_REQUEST
+| 2.0
 
 | 0x05
 | SYSIRQ_SET_IRQ_STATE
 | NORMAL_REQUEST
+| 2.0
 
 | 0x06
 | SYSIRQ_GET_IRQ_STATE
 | NORMAL_REQUEST
+| 2.0
 
 | 0x07
 | SYSIRQ_SET_IRQ_TARGET
 | NORMAL_REQUEST
+| 2.0
 
 | 0x08
 | SYSIRQ_GET_IRQ_TARGET
 | NORMAL_REQUEST
+| 2.0
 
 | 0x09
 | SYSIRQ_CLAIM
 | NORMAL_REQUEST
+| 2.0
 |===
 
 

--- a/src/srvgrp-system-msi.adoc
+++ b/src/srvgrp-system-msi.adoc
@@ -72,39 +72,47 @@ service group:
 
 [#table_sysmsi_services]
 .SYSTEM_MSI Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | SYSMSI_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | SYSMSI_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | SYSMSI_GET_MSI_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | SYSMSI_SET_MSI_STATE
 | NORMAL_REQUEST
+| 1.0
 
 | 0x05
 | SYSMSI_GET_MSI_STATE
 | NORMAL_REQUEST
+| 1.0
 
 | 0x06
 | SYSMSI_SET_MSI_TARGET
 | NORMAL_REQUEST
+| 1.0
 
 | 0x07
 | SYSMSI_GET_MSI_TARGET
 | NORMAL_REQUEST
+| 1.0
 |===
 
 [#system-msi-notifications]

--- a/src/srvgrp-system-reset.adoc
+++ b/src/srvgrp-system-reset.adoc
@@ -31,23 +31,27 @@ The following table lists the services in the SYSTEM_RESET service group:
 
 [#table_sysreset_services]
 .SYSTEM_RESET Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | SYSRST_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | SYSRST_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | SYSRST_RESET
 | POSTED_REQUEST
+| 1.0
 |===
 
 [#section-reset-types]

--- a/src/srvgrp-system-suspend.adoc
+++ b/src/srvgrp-system-suspend.adoc
@@ -22,23 +22,27 @@ The following table lists the services in the SYSTEM_SUSPEND service group:
 
 [#table_syssuspend_services]
 .SYSTEM_SUSPEND Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | SYSSUSP_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | SYSSUSP_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | SYSSUSP_SUSPEND
 | NORMAL_REQUEST
+| 1.0
 |===
 
 [#section-suspend-types]

--- a/src/srvgrp-voltage.adoc
+++ b/src/srvgrp-voltage.adoc
@@ -20,43 +20,52 @@ voltage levels of these voltage domains. Each voltage domain is identified by
 The following table lists the services in the VOLTAGE service group:
 [#table_voltage_services]
 .VOLTAGE Services
-[cols="1, 3, 2", width=100%, align="center", options="header"]
+[cols="1, 3, 2, 1", width=100%, align="center", options="header"]
 |===
 | Service ID
 | Service Name
 | Request Type
+| RPMI Version
 
 | 0x01
 | VOLT_ENABLE_NOTIFICATION
 | NORMAL_REQUEST
+| 1.0
 
 | 0x02
 | VOLT_GET_NUM_DOMAINS
 | NORMAL_REQUEST
+| 1.0
 
 | 0x03
 | VOLT_GET_ATTRIBUTES
 | NORMAL_REQUEST
+| 1.0
 
 | 0x04
 | VOLT_GET_SUPPORTED_LEVELS
 | NORMAL_REQUEST
+| 1.0
 
 | 0x05
 | VOLT_SET_CONFIG
 | NORMAL_REQUEST
+| 1.0
 
 | 0x06
 | VOLT_GET_CONFIG
 | NORMAL_REQUEST
+| 1.0
 
 | 0x07
 | VOLT_SET_LEVEL
 | NORMAL_REQUEST
+| 1.0
 
 | 0x08
 | VOLT_GET_LEVEL
 | NORMAL_REQUEST
+| 1.0
 
 |===
 


### PR DESCRIPTION
1. RPMI spec allows to add services to service groups in later spec versions. This requires each service to be versioned with RPMI spec version for conformation so that services which are added in later RPMI spec versions can be marked accordingly.

2. Update the document development stage as Draft and version as v2.0
3. Remove the email-ids from the contributors details and only keep the names.